### PR TITLE
Fix silent failure in auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -46,19 +46,45 @@ jobs:
         id: auto-tag
         run: |
           # Run hewg auto-tag command with JSON output
+          # Capture both stdout and exit code, stderr goes to workflow log
+          set +e  # Temporarily disable exit on error
           result=$(deno run --allow-read --allow-env --allow-run src/main.ts auto-tag \
             --source-branch "${{ github.head_ref }}" \
             --target-branch "${{ github.base_ref }}" \
             --config ".github/project.toml" \
-            --json)
+            --json 2>&1)
+          exit_code=$?
+          set -e  # Re-enable exit on error
+
+          echo "::group::CLI Output"
+          echo "$result"
+          echo "::endgroup::"
+
+          # Check if command succeeded
+          if [ $exit_code -ne 0 ]; then
+            echo "::error::CLI exited with code $exit_code"
+            echo "result=$result" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          # Validate JSON before parsing
+          if ! echo "$result" | jq -e . > /dev/null 2>&1; then
+            echo "::error::Invalid JSON output from CLI"
+            echo "Raw output: $result"
+            exit 1
+          fi
 
           echo "result=$result" >> $GITHUB_OUTPUT
 
-          # Parse result
-          success=$(echo "$result" | jq -r '.success')
+          # Parse result safely with defaults
+          success=$(echo "$result" | jq -r '.success // "false"')
           if [ "$success" != "true" ]; then
-            error=$(echo "$result" | jq -r '.error')
+            error=$(echo "$result" | jq -r '.error // "Unknown error"')
+            context=$(echo "$result" | jq -r '.context // empty')
             echo "::error::Auto-tag failed: $error"
+            if [ -n "$context" ]; then
+              echo "Context: $context"
+            fi
             exit 1
           fi
 

--- a/docs/design/issue-#10-fix-auto-tag-silent-failure.md
+++ b/docs/design/issue-#10-fix-auto-tag-silent-failure.md
@@ -94,9 +94,9 @@ Add caching to avoid fresh downloads on each run:
 
 ```typescript
 interface FlagDefinition {
-  short: 'V',
-  long: 'verbose',
-  description: 'Enable verbose output for debugging',
+  short: 'V';
+  long: 'verbose';
+  description: 'Enable verbose output for debugging';
 }
 ```
 
@@ -179,6 +179,7 @@ log(`Latest tag: ${latestTag ?? '(none)'}`, verbose, jsonOutput);
 #### 3.2 Special Characters in Branch Name
 
 Branch names with `#`, spaces, etc. should work because:
+
 - GitHub Actions properly quotes the value
 - Deno's argument parsing handles quoted strings correctly
 
@@ -221,11 +222,11 @@ if (pushCode !== 0) {
 
 ## File Changes Summary
 
-| File | Changes |
-|------|---------|
-| `src/cli/commands/auto-tag.ts` | Add --verbose flag, improve error handling, add context |
-| `.github/workflows/auto-tag.yml` | Add robust error handling, optional caching |
-| `src/templates/auto-tag.yml` | Same changes as workflow (template for setup command) |
+| File                             | Changes                                                 |
+| -------------------------------- | ------------------------------------------------------- |
+| `src/cli/commands/auto-tag.ts`   | Add --verbose flag, improve error handling, add context |
+| `.github/workflows/auto-tag.yml` | Add robust error handling, optional caching             |
+| `src/templates/auto-tag.yml`     | Same changes as workflow (template for setup command)   |
 
 ## Testing Strategy
 
@@ -242,6 +243,7 @@ if (pushCode !== 0) {
 ## Rollback Plan
 
 If issues arise:
+
 1. Revert the commit
 2. Original behavior is restored
 3. No data loss possible (tags are independent)

--- a/docs/design/issue-#10-fix-auto-tag-silent-failure.md
+++ b/docs/design/issue-#10-fix-auto-tag-silent-failure.md
@@ -1,0 +1,247 @@
+# Design Document: Fix Auto Tag Silent Failure
+
+**Issue**: #10
+**Type**: Bugfix
+**Author**: Claude Code
+**Created**: 2026-01-07
+
+## Overview
+
+This document describes the design for fixing the silent failure in the Auto Tag workflow and improving its robustness.
+
+## Problem Analysis
+
+### Symptoms
+
+- Auto Tag workflow fails with exit code 1
+- No output from CLI (neither success JSON nor error JSON)
+- Failure occurs ~125ms after Deno finishes downloading dependencies
+
+### Root Cause Analysis
+
+The failure occurs due to a combination of factors:
+
+1. **Workflow Script Issue**: The bash script uses `set -e` (exit on error)
+2. **jq Parse Failure**: When CLI output is empty or invalid JSON, `jq` fails
+3. **Silent Exit**: With `set -e`, bash exits immediately on jq failure without custom error message
+
+### Code Flow Analysis
+
+```
+Workflow starts
+    ↓
+deno run auto-tag ... (captured in $result)
+    ↓
+If CLI fails → $result is empty or contains error
+    ↓
+jq -r '.success' on empty $result → jq fails with exit code 5
+    ↓
+bash exits immediately due to set -e
+    ↓
+No custom error message displayed
+```
+
+## Solution Design
+
+### 1. Workflow Improvements (`.github/workflows/auto-tag.yml`)
+
+#### 1.1 Robust Error Handling
+
+```yaml
+- name: Run auto-tag command
+  id: auto-tag
+  run: |
+    # Capture both stdout and stderr
+    set +e  # Temporarily disable exit on error
+    result=$(deno run ... 2>&1)
+    exit_code=$?
+    set -e
+
+    # Check if command succeeded
+    if [ $exit_code -ne 0 ]; then
+      echo "::error::CLI failed with exit code $exit_code"
+      echo "Output: $result"
+      exit 1
+    fi
+
+    # Validate JSON before parsing
+    if ! echo "$result" | jq -e . > /dev/null 2>&1; then
+      echo "::error::Invalid JSON output from CLI"
+      echo "Output: $result"
+      exit 1
+    fi
+
+    # Parse JSON safely
+    success=$(echo "$result" | jq -r '.success // "false"')
+    ...
+```
+
+#### 1.2 Deno Dependency Caching (Optional)
+
+Add caching to avoid fresh downloads on each run:
+
+```yaml
+- name: Cache Deno dependencies
+  uses: actions/cache@v4
+  with:
+    path: ~/.cache/deno
+    key: deno-${{ hashFiles('deno.lock') }}
+```
+
+### 2. CLI Improvements (`src/cli/commands/auto-tag.ts`)
+
+#### 2.1 Add `--verbose` Flag
+
+```typescript
+interface FlagDefinition {
+  short: 'V',
+  long: 'verbose',
+  description: 'Enable verbose output for debugging',
+}
+```
+
+#### 2.2 Verbose Logging Helper
+
+```typescript
+function log(message: string, verbose: boolean, jsonOutput: boolean): void {
+  if (verbose && !jsonOutput) {
+    console.error(`[DEBUG] ${message}`);
+  }
+}
+```
+
+Note: Verbose output goes to stderr to not interfere with JSON output on stdout.
+
+#### 2.3 Enhanced Error Context
+
+```typescript
+interface AutoTagResult {
+  success: boolean;
+  currentTag: string | null;
+  newTag: string | null;
+  label: string;
+  incrementType: 'MAJOR' | 'MINOR' | 'PATCH' | 'RC_ONLY';
+  targetBranch: string;
+  isDevelopToMain: boolean;
+  error?: string;
+  context?: {
+    sourceBranch: string;
+    configPath: string;
+    gitDescribeOutput?: string;
+  };
+}
+```
+
+#### 2.4 Wrap Entire Function in Try-Catch
+
+Move try-catch to encompass the entire function including flag extraction:
+
+```typescript
+async function autoTagAction(ctx: CommandContext): Promise<void> {
+  let jsonOutput = false;
+  let verbose = false;
+
+  try {
+    // Extract flags first
+    jsonOutput = ctx.flags['json'] as boolean ?? false;
+    verbose = ctx.flags['verbose'] as boolean ?? false;
+
+    log('Starting auto-tag command', verbose, jsonOutput);
+    log(`Flags: ${JSON.stringify(ctx.flags)}`, verbose, jsonOutput);
+
+    // ... rest of implementation
+  } catch (error) {
+    // Always output JSON if possible, fallback to stderr
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    if (jsonOutput) {
+      console.log(JSON.stringify({ success: false, error: errorMessage }));
+    } else {
+      console.error(`Error: ${errorMessage}`);
+    }
+    Deno.exit(1);
+  }
+}
+```
+
+### 3. Edge Case Handling
+
+#### 3.1 No Tags Exist (First Run)
+
+Current behavior is correct - `getLatestTag()` returns null, `parseVersion(null)` returns `{0,0,0,null}`.
+
+Add verbose logging:
+
+```typescript
+const latestTag = await getLatestTag();
+log(`Latest tag: ${latestTag ?? '(none)'}`, verbose, jsonOutput);
+```
+
+#### 3.2 Special Characters in Branch Name
+
+Branch names with `#`, spaces, etc. should work because:
+- GitHub Actions properly quotes the value
+- Deno's argument parsing handles quoted strings correctly
+
+Add validation and logging:
+
+```typescript
+log(`Source branch: "${sourceBranch}"`, verbose, jsonOutput);
+if (sourceBranch.includes('#')) {
+  log('Branch name contains # character (handled correctly)', verbose, jsonOutput);
+}
+```
+
+#### 3.3 Tag Already Exists
+
+Current behavior throws an error. Improve the error message:
+
+```typescript
+if (createCode !== 0) {
+  const errorMsg = new TextDecoder().decode(createStderr).trim();
+  if (errorMsg.includes('already exists')) {
+    throw new Error(`Tag ${newTag} already exists. Delete it first or use a different version.`);
+  }
+  throw new Error(`Failed to create tag: ${errorMsg}`);
+}
+```
+
+#### 3.4 Network Error on Push
+
+Current behavior throws an error. Improve the error message:
+
+```typescript
+if (pushCode !== 0) {
+  const errorMsg = new TextDecoder().decode(pushStderr).trim();
+  if (errorMsg.includes('Could not resolve host') || errorMsg.includes('Connection refused')) {
+    throw new Error(`Network error while pushing tag. Check your internet connection: ${errorMsg}`);
+  }
+  throw new Error(`Failed to push tag: ${errorMsg}`);
+}
+```
+
+## File Changes Summary
+
+| File | Changes |
+|------|---------|
+| `src/cli/commands/auto-tag.ts` | Add --verbose flag, improve error handling, add context |
+| `.github/workflows/auto-tag.yml` | Add robust error handling, optional caching |
+| `src/templates/auto-tag.yml` | Same changes as workflow (template for setup command) |
+
+## Testing Strategy
+
+1. **Unit Tests**: Test individual functions (parseVersion, extractLabel, etc.)
+2. **Integration Tests**: Test CLI with various inputs including edge cases
+3. **Manual Tests**: Create PR with `#` in branch name and verify workflow
+
+## Compatibility
+
+- JSON output format remains backward compatible
+- New `--verbose` flag is optional
+- Existing workflows continue to work
+
+## Rollback Plan
+
+If issues arise:
+1. Revert the commit
+2. Original behavior is restored
+3. No data loss possible (tags are independent)

--- a/docs/workflow/issue-#10-fix-auto-tag-silent-failure.md
+++ b/docs/workflow/issue-#10-fix-auto-tag-silent-failure.md
@@ -15,6 +15,7 @@
 3. Add verbose logging throughout the command
 
 **Acceptance Criteria**:
+
 - [ ] `--verbose` or `-V` flag is available
 - [ ] Verbose output goes to stderr (not stdout)
 - [ ] Does not interfere with JSON output
@@ -28,6 +29,7 @@
 3. Add context information to error output
 
 **Acceptance Criteria**:
+
 - [ ] Any error produces valid JSON when `--json` is set
 - [ ] Error messages include context (branch name, config path)
 - [ ] No silent failures
@@ -41,6 +43,7 @@
 3. Add validation for branch names
 
 **Acceptance Criteria**:
+
 - [ ] Clear error message when tag already exists
 - [ ] Clear error message on network failure
 - [ ] Special characters in branch names handled correctly
@@ -56,6 +59,7 @@
 3. Display actual error output on failure
 
 **Changes**:
+
 ```yaml
 run: |
   set +e
@@ -79,6 +83,7 @@ run: |
 ```
 
 **Acceptance Criteria**:
+
 - [ ] Error output is visible in workflow logs
 - [ ] jq failures are handled gracefully
 - [ ] Actual error message is displayed
@@ -96,6 +101,7 @@ Apply same changes as workflow file.
 **File**: `tests/cli/commands/auto-tag.test.ts`
 
 Test functions:
+
 - `parseVersion()` - various version formats
 - `extractLabel()` - branch name parsing
 - `getIncrementType()` - label to increment mapping
@@ -130,13 +136,13 @@ deno test --allow-read --allow-env
 
 ## Commit Strategy
 
-| Commit | Description |
-|--------|-------------|
-| 1 | Add --verbose flag to auto-tag command |
-| 2 | Improve error handling in auto-tag command |
-| 3 | Fix workflow error handling and add stderr capture |
-| 4 | Add unit tests for auto-tag functions |
-| 5 | Add design and workflow documentation |
+| Commit | Description                                        |
+| ------ | -------------------------------------------------- |
+| 1      | Add --verbose flag to auto-tag command             |
+| 2      | Improve error handling in auto-tag command         |
+| 3      | Fix workflow error handling and add stderr capture |
+| 4      | Add unit tests for auto-tag functions              |
+| 5      | Add design and workflow documentation              |
 
 ## Verification Checklist
 

--- a/docs/workflow/issue-#10-fix-auto-tag-silent-failure.md
+++ b/docs/workflow/issue-#10-fix-auto-tag-silent-failure.md
@@ -1,0 +1,150 @@
+# Implementation Workflow: Fix Auto Tag Silent Failure
+
+**Issue**: #10
+**Branch**: `bugfix/wtisd/#10/fix-auto-tag-silent-failure`
+**Created**: 2026-01-07
+
+## Phase 1: CLI Improvements
+
+### Step 1.1: Add --verbose Flag
+
+**File**: `src/cli/commands/auto-tag.ts`
+
+1. Add verbose flag to command definition
+2. Create logging helper function
+3. Add verbose logging throughout the command
+
+**Acceptance Criteria**:
+- [ ] `--verbose` or `-V` flag is available
+- [ ] Verbose output goes to stderr (not stdout)
+- [ ] Does not interfere with JSON output
+
+### Step 1.2: Improve Error Handling
+
+**File**: `src/cli/commands/auto-tag.ts`
+
+1. Wrap entire autoTagAction in try-catch
+2. Ensure JSON output is always produced when `--json` is set
+3. Add context information to error output
+
+**Acceptance Criteria**:
+- [ ] Any error produces valid JSON when `--json` is set
+- [ ] Error messages include context (branch name, config path)
+- [ ] No silent failures
+
+### Step 1.3: Edge Case Handling
+
+**File**: `src/cli/commands/auto-tag.ts`
+
+1. Improve error messages for "tag exists" case
+2. Improve error messages for network failures
+3. Add validation for branch names
+
+**Acceptance Criteria**:
+- [ ] Clear error message when tag already exists
+- [ ] Clear error message on network failure
+- [ ] Special characters in branch names handled correctly
+
+## Phase 2: Workflow Improvements
+
+### Step 2.1: Add Robust Error Handling
+
+**File**: `.github/workflows/auto-tag.yml`
+
+1. Capture stderr alongside stdout
+2. Handle jq parse failures gracefully
+3. Display actual error output on failure
+
+**Changes**:
+```yaml
+run: |
+  set +e
+  output=$(deno run ... 2>&1)
+  exit_code=$?
+  set -e
+
+  if [ $exit_code -ne 0 ]; then
+    echo "::error::Command failed"
+    echo "$output"
+    exit 1
+  fi
+
+  # Validate JSON
+  if ! echo "$output" | jq -e . > /dev/null 2>&1; then
+    echo "::error::Invalid JSON"
+    echo "$output"
+    exit 1
+  fi
+  ...
+```
+
+**Acceptance Criteria**:
+- [ ] Error output is visible in workflow logs
+- [ ] jq failures are handled gracefully
+- [ ] Actual error message is displayed
+
+### Step 2.2: Update Template
+
+**File**: `src/templates/auto-tag.yml`
+
+Apply same changes as workflow file.
+
+## Phase 3: Testing
+
+### Step 3.1: Add Unit Tests
+
+**File**: `tests/cli/commands/auto-tag.test.ts`
+
+Test functions:
+- `parseVersion()` - various version formats
+- `extractLabel()` - branch name parsing
+- `getIncrementType()` - label to increment mapping
+- `calculateNewVersion()` - version calculation
+
+### Step 3.2: Manual Testing
+
+1. Run CLI with `--verbose` flag
+2. Test with branch name containing `#`
+3. Test error cases (no config file, invalid config)
+
+## Phase 4: Quality Checks
+
+### Step 4.1: Run Lint and Format
+
+```bash
+deno fmt
+deno lint
+```
+
+### Step 4.2: Run Type Check
+
+```bash
+deno check src/**/*.ts
+```
+
+### Step 4.3: Run Tests
+
+```bash
+deno test --allow-read --allow-env
+```
+
+## Commit Strategy
+
+| Commit | Description |
+|--------|-------------|
+| 1 | Add --verbose flag to auto-tag command |
+| 2 | Improve error handling in auto-tag command |
+| 3 | Fix workflow error handling and add stderr capture |
+| 4 | Add unit tests for auto-tag functions |
+| 5 | Add design and workflow documentation |
+
+## Verification Checklist
+
+Before creating PR:
+
+- [ ] All tests pass
+- [ ] `deno fmt --check` passes
+- [ ] `deno lint` passes
+- [ ] `deno check` passes
+- [ ] Manual test with verbose flag works
+- [ ] Documentation is complete

--- a/src/cli/commands/auto-tag.ts
+++ b/src/cli/commands/auto-tag.ts
@@ -543,3 +543,12 @@ export const autoTagCommand: Command = {
   ],
   action: autoTagAction,
 };
+
+// Export internal functions for testing
+export const _internals = {
+  parseVersion,
+  extractLabel,
+  getIncrementType,
+  calculateNewVersion,
+  parseToml,
+};

--- a/src/cli/commands/auto-tag.ts
+++ b/src/cli/commands/auto-tag.ts
@@ -330,7 +330,11 @@ async function autoTagAction(ctx: CommandContext): Promise<void> {
     const dryRun = (ctx.flags['dry-run'] as boolean) ?? false;
 
     debugLog('Starting auto-tag command', verbose, jsonOutput);
-    debugLog(`Flags: source-branch="${sourceBranch}", target-branch="${targetBranch}", config="${configPath}", json=${jsonOutput}, dry-run=${dryRun}`, verbose, jsonOutput);
+    debugLog(
+      `Flags: source-branch="${sourceBranch}", target-branch="${targetBranch}", config="${configPath}", json=${jsonOutput}, dry-run=${dryRun}`,
+      verbose,
+      jsonOutput,
+    );
 
     // Validate required flags
     if (!sourceBranch) {
@@ -351,7 +355,13 @@ async function autoTagAction(ctx: CommandContext): Promise<void> {
     // Load configuration
     debugLog(`Loading config from: ${configPath}`, verbose, jsonOutput);
     const config = await loadConfig(configPath);
-    debugLog(`Config loaded: majorLabels=${JSON.stringify(config.majorLabels)}, minorLabels=${JSON.stringify(config.minorLabels)}, patchLabels=${JSON.stringify(config.patchLabels)}`, verbose, jsonOutput);
+    debugLog(
+      `Config loaded: majorLabels=${JSON.stringify(config.majorLabels)}, minorLabels=${
+        JSON.stringify(config.minorLabels)
+      }, patchLabels=${JSON.stringify(config.patchLabels)}`,
+      verbose,
+      jsonOutput,
+    );
 
     // Get latest tag
     debugLog('Getting latest git tag...', verbose, jsonOutput);
@@ -421,7 +431,9 @@ async function autoTagAction(ctx: CommandContext): Promise<void> {
         const errorMsg = new TextDecoder().decode(createStderr).trim();
         debugLog(`git tag failed with code ${createCode}: ${errorMsg}`, verbose, jsonOutput);
         if (errorMsg.includes('already exists')) {
-          throw new Error(`Tag ${newTag} already exists. Delete it first or use a different version.`);
+          throw new Error(
+            `Tag ${newTag} already exists. Delete it first or use a different version.`,
+          );
         }
         throw new Error(`Failed to create tag: ${errorMsg}`);
       }
@@ -439,7 +451,9 @@ async function autoTagAction(ctx: CommandContext): Promise<void> {
       if (pushCode !== 0) {
         const errorMsg = new TextDecoder().decode(pushStderr).trim();
         debugLog(`git push failed with code ${pushCode}: ${errorMsg}`, verbose, jsonOutput);
-        if (errorMsg.includes('Could not resolve host') || errorMsg.includes('Connection refused')) {
+        if (
+          errorMsg.includes('Could not resolve host') || errorMsg.includes('Connection refused')
+        ) {
           throw new Error(`Network error while pushing tag: ${errorMsg}`);
         }
         throw new Error(`Failed to push tag: ${errorMsg}`);
@@ -477,7 +491,13 @@ async function autoTagAction(ctx: CommandContext): Promise<void> {
     } else {
       console.error(colors.error(`\n❌ Error: ${errorMessage}\n`));
       if (sourceBranch || targetBranch) {
-        console.error(colors.muted(`Context: source-branch="${sourceBranch ?? ''}", target-branch="${targetBranch ?? ''}", config="${configPath}"`));
+        console.error(
+          colors.muted(
+            `Context: source-branch="${sourceBranch ?? ''}", target-branch="${
+              targetBranch ?? ''
+            }", config="${configPath}"`,
+          ),
+        );
       }
     }
     Deno.exit(1);

--- a/src/cli/commands/auto-tag.ts
+++ b/src/cli/commands/auto-tag.ts
@@ -46,6 +46,23 @@ interface AutoTagResult {
   targetBranch: string;
   isDevelopToMain: boolean;
   error?: string;
+  context?: {
+    sourceBranch: string;
+    configPath: string;
+  };
+}
+
+/**
+ * Log a debug message to stderr (to not interfere with JSON output on stdout)
+ *
+ * @param message - Message to log
+ * @param verbose - Whether verbose mode is enabled
+ * @param jsonOutput - Whether JSON output mode is enabled
+ */
+function debugLog(message: string, verbose: boolean, jsonOutput: boolean): void {
+  if (verbose && !jsonOutput) {
+    console.error(colors.muted(`[DEBUG] ${message}`));
+  }
 }
 
 /**
@@ -296,58 +313,70 @@ async function loadConfig(configPath: string): Promise<TagConfig> {
  * Action handler for the auto-tag command
  */
 async function autoTagAction(ctx: CommandContext): Promise<void> {
-  const sourceBranch = ctx.flags['source-branch'] as string | undefined;
-  const targetBranch = ctx.flags['target-branch'] as string | undefined;
-  const configPath = (ctx.flags['config'] as string) || '.github/project.toml';
-  const jsonOutput = ctx.flags['json'] as boolean | undefined;
-  const dryRun = ctx.flags['dry-run'] as boolean | undefined;
-
-  // Validate required flags
-  if (!sourceBranch) {
-    const error = 'Error: --source-branch is required';
-    if (jsonOutput) {
-      console.log(JSON.stringify({ success: false, error }));
-    } else {
-      console.error(colors.error(error));
-    }
-    Deno.exit(1);
-  }
-
-  if (!targetBranch) {
-    const error = 'Error: --target-branch is required';
-    if (jsonOutput) {
-      console.log(JSON.stringify({ success: false, error }));
-    } else {
-      console.error(colors.error(error));
-    }
-    Deno.exit(1);
-  }
-
-  // Type narrowing: after validation, these are guaranteed to be strings
-  const source: string = sourceBranch;
-  const target: string = targetBranch;
+  // Initialize flags with defaults - these are used in error handling
+  let jsonOutput = false;
+  let verbose = false;
+  let sourceBranch: string | undefined;
+  let targetBranch: string | undefined;
+  let configPath = '.github/project.toml';
 
   try {
+    // Extract flags
+    sourceBranch = ctx.flags['source-branch'] as string | undefined;
+    targetBranch = ctx.flags['target-branch'] as string | undefined;
+    configPath = (ctx.flags['config'] as string) || '.github/project.toml';
+    jsonOutput = (ctx.flags['json'] as boolean) ?? false;
+    verbose = (ctx.flags['verbose'] as boolean) ?? false;
+    const dryRun = (ctx.flags['dry-run'] as boolean) ?? false;
+
+    debugLog('Starting auto-tag command', verbose, jsonOutput);
+    debugLog(`Flags: source-branch="${sourceBranch}", target-branch="${targetBranch}", config="${configPath}", json=${jsonOutput}, dry-run=${dryRun}`, verbose, jsonOutput);
+
+    // Validate required flags
+    if (!sourceBranch) {
+      throw new Error('--source-branch is required');
+    }
+
+    if (!targetBranch) {
+      throw new Error('--target-branch is required');
+    }
+
+    // Type narrowing: after validation, these are guaranteed to be strings
+    const source: string = sourceBranch;
+    const target: string = targetBranch;
+
+    debugLog(`Source branch: "${source}"`, verbose, jsonOutput);
+    debugLog(`Target branch: "${target}"`, verbose, jsonOutput);
+
     // Load configuration
+    debugLog(`Loading config from: ${configPath}`, verbose, jsonOutput);
     const config = await loadConfig(configPath);
+    debugLog(`Config loaded: majorLabels=${JSON.stringify(config.majorLabels)}, minorLabels=${JSON.stringify(config.minorLabels)}, patchLabels=${JSON.stringify(config.patchLabels)}`, verbose, jsonOutput);
 
     // Get latest tag
+    debugLog('Getting latest git tag...', verbose, jsonOutput);
     const latestTag = await getLatestTag();
+    debugLog(`Latest tag: ${latestTag ?? '(none)'}`, verbose, jsonOutput);
 
     // Parse current version
     const currentVersion = parseVersion(latestTag);
+    debugLog(`Parsed version: ${JSON.stringify(currentVersion)}`, verbose, jsonOutput);
 
     // Check if this is a develop -> main merge
     const isDevelopToMain = target === 'main' && source === 'develop';
+    debugLog(`Is develop→main merge: ${isDevelopToMain}`, verbose, jsonOutput);
 
     // Extract label from source branch
     const label = extractLabel(source);
+    debugLog(`Extracted label: "${label}"`, verbose, jsonOutput);
 
     // Get increment type
     const incrementType = getIncrementType(label, config);
+    debugLog(`Increment type: ${incrementType}`, verbose, jsonOutput);
 
     // Calculate new version
     const newTag = calculateNewVersion(currentVersion, incrementType, target, isDevelopToMain);
+    debugLog(`Calculated new tag: ${newTag}`, verbose, jsonOutput);
 
     const result: AutoTagResult = {
       success: true,
@@ -379,6 +408,7 @@ async function autoTagAction(ctx: CommandContext): Promise<void> {
 
     // Create tag if not dry run
     if (!dryRun) {
+      debugLog(`Creating annotated tag: ${newTag}`, verbose, jsonOutput);
       const tagMessage = `Release ${newTag}`;
       const createCommand = new Deno.Command('git', {
         args: ['tag', '-a', newTag, '-m', tagMessage],
@@ -388,11 +418,17 @@ async function autoTagAction(ctx: CommandContext): Promise<void> {
 
       const { code: createCode, stderr: createStderr } = await createCommand.output();
       if (createCode !== 0) {
-        const errorMsg = new TextDecoder().decode(createStderr);
+        const errorMsg = new TextDecoder().decode(createStderr).trim();
+        debugLog(`git tag failed with code ${createCode}: ${errorMsg}`, verbose, jsonOutput);
+        if (errorMsg.includes('already exists')) {
+          throw new Error(`Tag ${newTag} already exists. Delete it first or use a different version.`);
+        }
         throw new Error(`Failed to create tag: ${errorMsg}`);
       }
+      debugLog('Tag created successfully', verbose, jsonOutput);
 
       // Push tag
+      debugLog(`Pushing tag to origin: ${newTag}`, verbose, jsonOutput);
       const pushCommand = new Deno.Command('git', {
         args: ['push', 'origin', newTag],
         stdout: 'piped',
@@ -401,20 +437,48 @@ async function autoTagAction(ctx: CommandContext): Promise<void> {
 
       const { code: pushCode, stderr: pushStderr } = await pushCommand.output();
       if (pushCode !== 0) {
-        const errorMsg = new TextDecoder().decode(pushStderr);
+        const errorMsg = new TextDecoder().decode(pushStderr).trim();
+        debugLog(`git push failed with code ${pushCode}: ${errorMsg}`, verbose, jsonOutput);
+        if (errorMsg.includes('Could not resolve host') || errorMsg.includes('Connection refused')) {
+          throw new Error(`Network error while pushing tag: ${errorMsg}`);
+        }
         throw new Error(`Failed to push tag: ${errorMsg}`);
       }
+      debugLog('Tag pushed successfully', verbose, jsonOutput);
 
       if (!jsonOutput) {
         console.log(colors.success(`✓ Tag ${newTag} created and pushed`));
       }
+    } else {
+      debugLog('Dry run mode - skipping tag creation', verbose, jsonOutput);
     }
+
+    debugLog('Auto-tag command completed successfully', verbose, jsonOutput);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
+    debugLog(`Error occurred: ${errorMessage}`, verbose, jsonOutput);
+
     if (jsonOutput) {
-      console.log(JSON.stringify({ success: false, error: errorMessage }));
+      const errorResult: AutoTagResult = {
+        success: false,
+        currentTag: null,
+        newTag: null,
+        label: '',
+        incrementType: 'PATCH',
+        targetBranch: targetBranch ?? '',
+        isDevelopToMain: false,
+        error: errorMessage,
+        context: {
+          sourceBranch: sourceBranch ?? '',
+          configPath,
+        },
+      };
+      console.log(JSON.stringify(errorResult));
     } else {
       console.error(colors.error(`\n❌ Error: ${errorMessage}\n`));
+      if (sourceBranch || targetBranch) {
+        console.error(colors.muted(`Context: source-branch="${sourceBranch ?? ''}", target-branch="${targetBranch ?? ''}", config="${configPath}"`));
+      }
     }
     Deno.exit(1);
   }
@@ -470,6 +534,11 @@ export const autoTagCommand: Command = {
       short: 'n',
       long: 'dry-run',
       description: 'Calculate version without creating tag',
+    },
+    {
+      short: 'V',
+      long: 'verbose',
+      description: 'Enable verbose output for debugging (writes to stderr)',
     },
   ],
   action: autoTagAction,

--- a/src/templates/auto-tag.yml
+++ b/src/templates/auto-tag.yml
@@ -46,19 +46,45 @@ jobs:
         id: auto-tag
         run: |
           # Run hewg auto-tag command with JSON output
+          # Capture both stdout and exit code, stderr goes to workflow log
+          set +e  # Temporarily disable exit on error
           result=$(deno run --allow-read --allow-env --allow-run src/main.ts auto-tag \
             --source-branch "${{ github.head_ref }}" \
             --target-branch "${{ github.base_ref }}" \
             --config ".github/project.toml" \
-            --json)
+            --json 2>&1)
+          exit_code=$?
+          set -e  # Re-enable exit on error
+
+          echo "::group::CLI Output"
+          echo "$result"
+          echo "::endgroup::"
+
+          # Check if command succeeded
+          if [ $exit_code -ne 0 ]; then
+            echo "::error::CLI exited with code $exit_code"
+            echo "result=$result" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          # Validate JSON before parsing
+          if ! echo "$result" | jq -e . > /dev/null 2>&1; then
+            echo "::error::Invalid JSON output from CLI"
+            echo "Raw output: $result"
+            exit 1
+          fi
 
           echo "result=$result" >> $GITHUB_OUTPUT
 
-          # Parse result
-          success=$(echo "$result" | jq -r '.success')
+          # Parse result safely with defaults
+          success=$(echo "$result" | jq -r '.success // "false"')
           if [ "$success" != "true" ]; then
-            error=$(echo "$result" | jq -r '.error')
+            error=$(echo "$result" | jq -r '.error // "Unknown error"')
+            context=$(echo "$result" | jq -r '.context // empty')
             echo "::error::Auto-tag failed: $error"
+            if [ -n "$context" ]; then
+              echo "Context: $context"
+            fi
             exit 1
           fi
 

--- a/tests/auto-tag_test.ts
+++ b/tests/auto-tag_test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for auto-tag command functions
+ */
+
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+import { _internals } from '../src/cli/commands/auto-tag.ts';
+
+const { parseVersion, extractLabel, getIncrementType, calculateNewVersion, parseToml } = _internals;
+
+describe('parseVersion', () => {
+  it('should parse a simple version tag', () => {
+    const result = parseVersion('v1.2.3');
+    assertEquals(result, { major: 1, minor: 2, patch: 3, rc: null });
+  });
+
+  it('should parse a version tag with RC suffix', () => {
+    const result = parseVersion('v1.2.3-rc.4');
+    assertEquals(result, { major: 1, minor: 2, patch: 3, rc: 4 });
+  });
+
+  it('should handle version without v prefix', () => {
+    const result = parseVersion('1.2.3');
+    assertEquals(result, { major: 1, minor: 2, patch: 3, rc: null });
+  });
+
+  it('should return zeros for null input', () => {
+    const result = parseVersion(null);
+    assertEquals(result, { major: 0, minor: 0, patch: 0, rc: null });
+  });
+
+  it('should return zeros for invalid version format', () => {
+    const result = parseVersion('invalid');
+    assertEquals(result, { major: 0, minor: 0, patch: 0, rc: null });
+  });
+
+  it('should handle v0.0.0', () => {
+    const result = parseVersion('v0.0.0');
+    assertEquals(result, { major: 0, minor: 0, patch: 0, rc: null });
+  });
+
+  it('should handle RC version 0', () => {
+    const result = parseVersion('v1.0.0-rc.0');
+    assertEquals(result, { major: 1, minor: 0, patch: 0, rc: 0 });
+  });
+});
+
+describe('extractLabel', () => {
+  it('should extract label from standard branch name', () => {
+    const result = extractLabel('feature/wtisd/8/auto-tag');
+    assertEquals(result, 'feature');
+  });
+
+  it('should extract label from branch with # in name', () => {
+    const result = extractLabel('feature/wtisd/#8/auto-tag-workflow');
+    assertEquals(result, 'feature');
+  });
+
+  it('should extract label from bugfix branch', () => {
+    const result = extractLabel('bugfix/wtisd/10/fix-something');
+    assertEquals(result, 'bugfix');
+  });
+
+  it('should handle branch name without slashes', () => {
+    const result = extractLabel('main');
+    assertEquals(result, 'main');
+  });
+
+  it('should handle empty string', () => {
+    const result = extractLabel('');
+    assertEquals(result, '');
+  });
+
+  it('should handle develop branch', () => {
+    const result = extractLabel('develop');
+    assertEquals(result, 'develop');
+  });
+});
+
+describe('getIncrementType', () => {
+  const config = {
+    majorLabels: ['release'],
+    minorLabels: ['feature'],
+    patchLabels: ['bugfix', 'fix', 'patch', 'hotfix'],
+  };
+
+  it('should return MAJOR for release label', () => {
+    const result = getIncrementType('release', config);
+    assertEquals(result, 'MAJOR');
+  });
+
+  it('should return MINOR for feature label', () => {
+    const result = getIncrementType('feature', config);
+    assertEquals(result, 'MINOR');
+  });
+
+  it('should return PATCH for bugfix label', () => {
+    const result = getIncrementType('bugfix', config);
+    assertEquals(result, 'PATCH');
+  });
+
+  it('should return PATCH for fix label', () => {
+    const result = getIncrementType('fix', config);
+    assertEquals(result, 'PATCH');
+  });
+
+  it('should return PATCH for hotfix label', () => {
+    const result = getIncrementType('hotfix', config);
+    assertEquals(result, 'PATCH');
+  });
+
+  it('should return RC_ONLY for unknown label', () => {
+    const result = getIncrementType('refactor', config);
+    assertEquals(result, 'RC_ONLY');
+  });
+
+  it('should return RC_ONLY for docs label', () => {
+    const result = getIncrementType('docs', config);
+    assertEquals(result, 'RC_ONLY');
+  });
+});
+
+describe('calculateNewVersion', () => {
+  describe('for develop branch (RC versions)', () => {
+    it('should create MINOR RC version for feature', () => {
+      const current = { major: 1, minor: 2, patch: 3, rc: null };
+      const result = calculateNewVersion(current, 'MINOR', 'develop', false);
+      assertEquals(result, 'v1.3.0-rc.0');
+    });
+
+    it('should create MAJOR RC version for release', () => {
+      const current = { major: 1, minor: 2, patch: 3, rc: null };
+      const result = calculateNewVersion(current, 'MAJOR', 'develop', false);
+      assertEquals(result, 'v2.0.0-rc.0');
+    });
+
+    it('should create PATCH RC version for bugfix', () => {
+      const current = { major: 1, minor: 2, patch: 3, rc: null };
+      const result = calculateNewVersion(current, 'PATCH', 'develop', false);
+      assertEquals(result, 'v1.2.4-rc.0');
+    });
+
+    it('should increment RC counter for RC_ONLY', () => {
+      const current = { major: 1, minor: 2, patch: 3, rc: 0 };
+      const result = calculateNewVersion(current, 'RC_ONLY', 'develop', false);
+      assertEquals(result, 'v1.2.3-rc.1');
+    });
+
+    it('should start RC from 0 when no previous RC', () => {
+      const current = { major: 1, minor: 2, patch: 3, rc: null };
+      const result = calculateNewVersion(current, 'RC_ONLY', 'develop', false);
+      assertEquals(result, 'v1.2.3-rc.0');
+    });
+
+    it('should handle first version (v0.0.0)', () => {
+      const current = { major: 0, minor: 0, patch: 0, rc: null };
+      const result = calculateNewVersion(current, 'MINOR', 'develop', false);
+      assertEquals(result, 'v0.1.0-rc.0');
+    });
+  });
+
+  describe('for main branch (release versions)', () => {
+    it('should create MINOR release version', () => {
+      const current = { major: 1, minor: 2, patch: 3, rc: null };
+      const result = calculateNewVersion(current, 'MINOR', 'main', false);
+      assertEquals(result, 'v1.3.0');
+    });
+
+    it('should create MAJOR release version', () => {
+      const current = { major: 1, minor: 2, patch: 3, rc: null };
+      const result = calculateNewVersion(current, 'MAJOR', 'main', false);
+      assertEquals(result, 'v2.0.0');
+    });
+
+    it('should create PATCH release version', () => {
+      const current = { major: 1, minor: 2, patch: 3, rc: null };
+      const result = calculateNewVersion(current, 'PATCH', 'main', false);
+      assertEquals(result, 'v1.2.4');
+    });
+
+    it('should default to PATCH for RC_ONLY on main', () => {
+      const current = { major: 1, minor: 2, patch: 3, rc: null };
+      const result = calculateNewVersion(current, 'RC_ONLY', 'main', false);
+      assertEquals(result, 'v1.2.4');
+    });
+  });
+
+  describe('for develop->main merge', () => {
+    it('should strip RC suffix', () => {
+      const current = { major: 1, minor: 2, patch: 3, rc: 5 };
+      const result = calculateNewVersion(current, 'MINOR', 'main', true);
+      assertEquals(result, 'v1.2.3');
+    });
+
+    it('should keep version numbers when stripping RC', () => {
+      const current = { major: 2, minor: 0, patch: 0, rc: 3 };
+      const result = calculateNewVersion(current, 'MAJOR', 'main', true);
+      assertEquals(result, 'v2.0.0');
+    });
+  });
+});
+
+describe('parseToml', () => {
+  it('should parse simple key-value pairs', () => {
+    const content = `
+[section]
+key = "value"
+number = 42
+`;
+    const result = parseToml(content);
+    assertEquals(result.section.key, 'value');
+    assertEquals(result.section.number, 42);
+  });
+
+  it('should parse arrays', () => {
+    const content = `
+[tag]
+major_labels = ["release"]
+minor_labels = ["feature"]
+`;
+    const result = parseToml(content);
+    assertEquals(result.tag.major_labels, ['release']);
+    assertEquals(result.tag.minor_labels, ['feature']);
+  });
+
+  it('should parse booleans', () => {
+    const content = `
+[settings]
+enabled = true
+disabled = false
+`;
+    const result = parseToml(content);
+    assertEquals(result.settings.enabled, true);
+    assertEquals(result.settings.disabled, false);
+  });
+
+  it('should skip comments', () => {
+    const content = `
+# This is a comment
+[section]
+# Another comment
+key = "value"
+`;
+    const result = parseToml(content);
+    assertEquals(result.section.key, 'value');
+  });
+
+  it('should handle multiple sections', () => {
+    const content = `
+[section1]
+key1 = "value1"
+
+[section2]
+key2 = "value2"
+`;
+    const result = parseToml(content);
+    assertEquals(result.section1.key1, 'value1');
+    assertEquals(result.section2.key2, 'value2');
+  });
+});


### PR DESCRIPTION
## Summary
- Fix silent failure when auto-tag CLI produces no output
- Add `--verbose` flag for debugging
- Improve error handling in workflow YAML

Closes #10

## 概要

Auto Tag ワークフローがサイレントに失敗する問題を修正しました。

### 問題の原因
- CLIが出力を生成する前にエラーで終了
- bashの`set -e`により、jqが無効なJSONをパースしようとして即座に終了
- エラーメッセージが表示されない

### 変更内容

**CLI改善 (`src/cli/commands/auto-tag.ts`)**
- `--verbose` (`-V`) フラグを追加（stderrにデバッグ出力）
- `autoTagAction`全体をtry-catchでラップ
- エラー出力にコンテキスト情報を追加
- テスト用に内部関数をエクスポート

**ワークフロー改善 (`.github/workflows/auto-tag.yml`, `src/templates/auto-tag.yml`)**
- `set +e`/`set -e`で終了コードを適切にキャプチャ
- `2>&1`でstderrもキャプチャ
- jqパース前にJSON検証を追加
- CLI出力を折りたたみグループで表示

**テスト追加 (`tests/auto-tag_test.ts`)**
- 36テストケース追加（parseVersion, extractLabel, getIncrementType, calculateNewVersion, parseToml）

**ドキュメント追加**
- `docs/design/issue-#10-fix-auto-tag-silent-failure.md`
- `docs/workflow/issue-#10-fix-auto-tag-silent-failure.md`

## Test plan
- [x] `deno test --allow-read --allow-env` - 23 tests, 88 steps passed
- [x] `deno fmt --check` - passed
- [x] `deno lint` - passed
- [ ] GitHub Actions CI/CD pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)