### PR TITLE
Fix git identity and duplicate JSON output in auto-tag

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -42,17 +42,22 @@ jobs:
         with:
           deno-version: v2.x
 
+      - name: Configure Git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Run auto-tag command
         id: auto-tag
         run: |
           # Run hewg auto-tag command with JSON output
-          # Capture both stdout and exit code, stderr goes to workflow log
+          # stdout = JSON result, stderr = Deno messages (displayed in workflow log)
           set +e  # Temporarily disable exit on error
           result=$(deno run --allow-read --allow-env --allow-run src/main.ts auto-tag \
             --source-branch "${{ github.head_ref }}" \
             --target-branch "${{ github.base_ref }}" \
             --config ".github/project.toml" \
-            --json 2>&1)
+            --json)
           exit_code=$?
           set -e  # Re-enable exit on error
 

--- a/src/cli/commands/auto-tag.ts
+++ b/src/cli/commands/auto-tag.ts
@@ -398,9 +398,8 @@ async function autoTagAction(ctx: CommandContext): Promise<void> {
       isDevelopToMain,
     };
 
-    if (jsonOutput) {
-      console.log(JSON.stringify(result));
-    } else {
+    // Show non-JSON output immediately (JSON output is deferred until after tag creation)
+    if (!jsonOutput) {
       console.log(colors.highlight('\n🏷️  Auto Tag Calculator\n'));
       console.log(`${colors.muted('Current tag:')} ${latestTag || '(none, starting from v0.0.0)'}`);
       console.log(`${colors.muted('Source branch:')} ${source}`);
@@ -465,6 +464,11 @@ async function autoTagAction(ctx: CommandContext): Promise<void> {
       }
     } else {
       debugLog('Dry run mode - skipping tag creation', verbose, jsonOutput);
+    }
+
+    // Output JSON only after all operations complete successfully
+    if (jsonOutput) {
+      console.log(JSON.stringify(result));
     }
 
     debugLog('Auto-tag command completed successfully', verbose, jsonOutput);

--- a/src/templates/auto-tag.yml
+++ b/src/templates/auto-tag.yml
@@ -42,17 +42,22 @@ jobs:
         with:
           deno-version: v2.x
 
+      - name: Configure Git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Run auto-tag command
         id: auto-tag
         run: |
           # Run hewg auto-tag command with JSON output
-          # Capture both stdout and exit code, stderr goes to workflow log
+          # stdout = JSON result, stderr = Deno messages (displayed in workflow log)
           set +e  # Temporarily disable exit on error
           result=$(deno run --allow-read --allow-env --allow-run src/main.ts auto-tag \
             --source-branch "${{ github.head_ref }}" \
             --target-branch "${{ github.base_ref }}" \
             --config ".github/project.toml" \
-            --json 2>&1)
+            --json)
           exit_code=$?
           set -e  # Re-enable exit on error
 


### PR DESCRIPTION
## Summary
- Fix git identity not configured error in GitHub Actions
- Fix Deno download messages mixing with JSON output
- Fix CLI outputting JSON twice (before and after tag creation)

Related to #10

## 変更内容

**ワークフロー改善**
- `git config` ステップを追加（github-actions[bot]として設定）
- `2>&1` を削除してDenoのダウンロードメッセージがJSON出力に混入しないように修正

**CLI改善**
- JSON出力をタグ作成完了後のみに変更（成功時と失敗時の重複出力を防止）

## Test plan
- [x] All tests pass
- [x] `deno fmt --check` passes
- [x] `deno lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)