### PR TITLE
Refactor workflow files to use hewg CLI commands

### DIFF
--- a/.github/workflows/issue-to-project.yml
+++ b/.github/workflows/issue-to-project.yml
@@ -20,321 +20,97 @@ jobs:
     name: Add Issue to Project
     runs-on: ubuntu-latest
     environment: project
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Add Issue to Project
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run link-issue command
+        id: link-issue
+        env:
+          PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          # Run hewg link-issue command with JSON output
+          # stdout = JSON result, stderr = Deno messages (displayed in workflow log)
+          set +e  # Temporarily disable exit on error
+          result=$(deno run --allow-read --allow-env --allow-net src/main.ts link-issue \
+            --issue-number "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --config ".github/project.toml" \
+            --json)
+          exit_code=$?
+          set -e  # Re-enable exit on error
+
+          echo "::group::CLI Output"
+          echo "$result"
+          echo "::endgroup::"
+
+          # Check if command succeeded
+          if [ $exit_code -ne 0 ]; then
+            echo "::error::CLI exited with code $exit_code"
+            echo "result=$result" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          # Validate JSON before parsing
+          if ! echo "$result" | jq -e . > /dev/null 2>&1; then
+            echo "::error::Invalid JSON output from CLI"
+            echo "Raw output: $result"
+            exit 1
+          fi
+
+          echo "result=$result" >> $GITHUB_OUTPUT
+
+          # Parse result safely with defaults
+          success=$(echo "$result" | jq -r '.success // "false"')
+          if [ "$success" != "true" ]; then
+            error=$(echo "$result" | jq -r '.error // "Unknown error"')
+            context=$(echo "$result" | jq -r '.context // empty')
+            echo "::error::Link-issue failed: $error"
+            if [ -n "$context" ]; then
+              echo "Context: $context"
+            fi
+            exit 1
+          fi
+
+          # Extract values for logging
+          echo "project_title=$(echo "$result" | jq -r '.projectTitle // ""')" >> $GITHUB_OUTPUT
+          echo "project_item_id=$(echo "$result" | jq -r '.projectItemId // ""')" >> $GITHUB_OUTPUT
+          echo "fields_set=$(echo "$result" | jq -r '.fieldsSet // [] | join(", ")')" >> $GITHUB_OUTPUT
+
+      - name: Log success
+        run: |
+          echo "✓ Issue #${{ github.event.issue.number }} added to project: ${{ steps.link-issue.outputs.project_title }}"
+          echo "  Item ID: ${{ steps.link-issue.outputs.project_item_id }}"
+          echo "  Fields set: ${{ steps.link-issue.outputs.fields_set }}"
+
+      - name: Handle failure
+        if: failure()
         uses: actions/github-script@v7
         env:
           PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
-            const fs = require('fs');
-
-            // Simple TOML parser for our specific use case
-            function parseToml(content) {
-              const result = { project: {}, defaults: {} };
-              let currentSection = null;
-
-              for (const line of content.split('\n')) {
-                const trimmed = line.trim();
-
-                // Skip empty lines and comments
-                if (!trimmed || trimmed.startsWith('#')) continue;
-
-                // Section header
-                const sectionMatch = trimmed.match(/^\[(\w+)\]$/);
-                if (sectionMatch) {
-                  currentSection = sectionMatch[1];
-                  if (!result[currentSection]) result[currentSection] = {};
-                  continue;
-                }
-
-                // Key-value pair
-                const kvMatch = trimmed.match(/^(\w+)\s*=\s*(.+)$/);
-                if (kvMatch && currentSection) {
-                  let value = kvMatch[2].trim();
-                  // Remove quotes from strings
-                  if ((value.startsWith('"') && value.endsWith('"')) ||
-                      (value.startsWith("'") && value.endsWith("'"))) {
-                    value = value.slice(1, -1);
-                  }
-                  // Parse numbers
-                  else if (/^\d+$/.test(value)) {
-                    value = parseInt(value, 10);
-                  }
-                  else if (/^\d+\.\d+$/.test(value)) {
-                    value = parseFloat(value);
-                  }
-                  result[currentSection][kvMatch[1]] = value;
-                }
-              }
-
-              return result;
-            }
-
-            // Parse project URL to extract owner and number
-            function parseProjectUrl(url) {
-              const userMatch = url.match(/github\.com\/users\/([^/]+)\/projects\/(\d+)/);
-              if (userMatch) {
-                return { owner: userMatch[1], number: parseInt(userMatch[2], 10), isOrg: false };
-              }
-              const orgMatch = url.match(/github\.com\/orgs\/([^/]+)\/projects\/(\d+)/);
-              if (orgMatch) {
-                return { owner: orgMatch[1], number: parseInt(orgMatch[2], 10), isOrg: true };
-              }
-              throw new Error(`Invalid project URL: ${url}`);
-            }
-
-            // Comment on issue with error message
-            async function commentError(message, runUrl) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: `:warning: **Failed to add this issue to the project**\n\n**Error**: ${message}\n\n**Troubleshooting**:\n- Ensure \`PROJECT_TOKEN\` secret is configured with \`project\` scope\n- Verify the project URL in \`.github/project.toml\`\n- Check that the token owner has access to the project\n\n[View workflow run](${runUrl})`
-              });
-            }
-
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
-            try {
-              // Read and parse config
-              const configPath = '.github/project.toml';
-              if (!fs.existsSync(configPath)) {
-                throw new Error(`Configuration file not found: ${configPath}`);
-              }
-
-              const configContent = fs.readFileSync(configPath, 'utf8');
-              const config = parseToml(configContent);
-
-              if (!config.project?.url) {
-                throw new Error('project.url is required in configuration');
-              }
-
-              const projectInfo = parseProjectUrl(config.project.url);
-              console.log(`Adding issue to project: ${projectInfo.owner}/${projectInfo.number}`);
-
-              // Get project ID
-              const projectQuery = projectInfo.isOrg ? `
-                query($owner: String!, $number: Int!) {
-                  organization(login: $owner) {
-                    projectV2(number: $number) {
-                      id
-                      title
-                      fields(first: 20) {
-                        nodes {
-                          ... on ProjectV2Field {
-                            id
-                            name
-                          }
-                          ... on ProjectV2SingleSelectField {
-                            id
-                            name
-                            options {
-                              id
-                              name
-                            }
-                          }
-                          ... on ProjectV2IterationField {
-                            id
-                            name
-                            configuration {
-                              iterations {
-                                id
-                                title
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              ` : `
-                query($owner: String!, $number: Int!) {
-                  user(login: $owner) {
-                    projectV2(number: $number) {
-                      id
-                      title
-                      fields(first: 20) {
-                        nodes {
-                          ... on ProjectV2Field {
-                            id
-                            name
-                          }
-                          ... on ProjectV2SingleSelectField {
-                            id
-                            name
-                            options {
-                              id
-                              name
-                            }
-                          }
-                          ... on ProjectV2IterationField {
-                            id
-                            name
-                            configuration {
-                              iterations {
-                                id
-                                title
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              `;
-
-              const projectResult = await github.graphql(projectQuery, {
-                owner: projectInfo.owner,
-                number: projectInfo.number
-              });
-
-              const project = projectInfo.isOrg
-                ? projectResult.organization?.projectV2
-                : projectResult.user?.projectV2;
-
-              if (!project) {
-                throw new Error(`Project not found: ${config.project.url}`);
-              }
-
-              console.log(`Found project: ${project.title} (${project.id})`);
-
-              // Add issue to project
-              const addResult = await github.graphql(`
-                mutation($projectId: ID!, $contentId: ID!) {
-                  addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
-                    item {
-                      id
-                    }
-                  }
-                }
-              `, {
-                projectId: project.id,
-                contentId: context.payload.issue.node_id
-              });
-
-              const itemId = addResult.addProjectV2ItemById.item.id;
-              console.log(`Added issue to project, item ID: ${itemId}`);
-
-              // Set default field values if configured
-              const defaults = config.defaults || {};
-              const fields = project.fields.nodes;
-
-              // Helper to find field and option
-              function findField(name) {
-                return fields.find(f => f.name?.toLowerCase() === name.toLowerCase());
-              }
-
-              function findOption(field, value) {
-                return field.options?.find(o => o.name?.toLowerCase() === value.toLowerCase());
-              }
-
-              // Set Status
-              if (defaults.status) {
-                const statusField = findField('Status');
-                if (statusField) {
-                  const option = findOption(statusField, defaults.status);
-                  if (option) {
-                    await github.graphql(`
-                      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
-                        updateProjectV2ItemFieldValue(
-                          input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: {singleSelectOptionId: $value}}
-                        ) { projectV2Item { id } }
-                      }
-                    `, { projectId: project.id, itemId, fieldId: statusField.id, value: option.id });
-                    console.log(`Set Status to: ${defaults.status}`);
-                  } else {
-                    console.log(`Warning: Status option '${defaults.status}' not found`);
-                  }
-                }
-              }
-
-              // Set Priority
-              if (defaults.priority) {
-                const priorityField = findField('Priority');
-                if (priorityField) {
-                  const option = findOption(priorityField, defaults.priority);
-                  if (option) {
-                    await github.graphql(`
-                      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
-                        updateProjectV2ItemFieldValue(
-                          input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: {singleSelectOptionId: $value}}
-                        ) { projectV2Item { id } }
-                      }
-                    `, { projectId: project.id, itemId, fieldId: priorityField.id, value: option.id });
-                    console.log(`Set Priority to: ${defaults.priority}`);
-                  } else {
-                    console.log(`Warning: Priority option '${defaults.priority}' not found`);
-                  }
-                }
-              }
-
-              // Set Iteration
-              if (defaults.iteration) {
-                const iterationField = findField('Iteration');
-                if (iterationField?.configuration?.iterations) {
-                  const iteration = iterationField.configuration.iterations.find(
-                    i => i.title?.toLowerCase() === defaults.iteration.toLowerCase()
-                  );
-                  if (iteration) {
-                    await github.graphql(`
-                      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
-                        updateProjectV2ItemFieldValue(
-                          input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: {iterationId: $value}}
-                        ) { projectV2Item { id } }
-                      }
-                    `, { projectId: project.id, itemId, fieldId: iterationField.id, value: iteration.id });
-                    console.log(`Set Iteration to: ${defaults.iteration}`);
-                  } else {
-                    console.log(`Warning: Iteration '${defaults.iteration}' not found`);
-                  }
-                }
-              }
-
-              // Set numeric fields (Size, Estimate)
-              for (const [key, fieldName] of [['size', 'Size'], ['estimate', 'Estimate']]) {
-                if (defaults[key] !== undefined) {
-                  const field = findField(fieldName);
-                  if (field) {
-                    await github.graphql(`
-                      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: Float!) {
-                        updateProjectV2ItemFieldValue(
-                          input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: {number: $value}}
-                        ) { projectV2Item { id } }
-                      }
-                    `, { projectId: project.id, itemId, fieldId: field.id, value: defaults[key] });
-                    console.log(`Set ${fieldName} to: ${defaults[key]}`);
-                  }
-                }
-              }
-
-              // Set date fields
-              for (const [key, fieldName] of [['start_date', 'Start date'], ['target_date', 'Target date']]) {
-                if (defaults[key]) {
-                  const field = findField(fieldName);
-                  if (field) {
-                    await github.graphql(`
-                      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: Date!) {
-                        updateProjectV2ItemFieldValue(
-                          input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: {date: $value}}
-                        ) { projectV2Item { id } }
-                      }
-                    `, { projectId: project.id, itemId, fieldId: field.id, value: defaults[key] });
-                    console.log(`Set ${fieldName} to: ${defaults[key]}`);
-                  }
-                }
-              }
-
-              console.log('Successfully added issue to project with default values');
-
-            } catch (error) {
-              console.error(`Error: ${error.message}`);
-              await commentError(error.message, runUrl);
-              core.setFailed(error.message);
-            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                ':warning: **Failed to add this issue to the project**',
+                '',
+                '**Troubleshooting**:',
+                '- Ensure `PROJECT_TOKEN` secret is configured with `project` scope',
+                '- Verify the project URL in `.github/project.toml`',
+                '- Check that the token owner has access to the project',
+                '',
+                `[View workflow run](${runUrl})`
+              ].join('\n')
+            });

--- a/.github/workflows/pr-status-update.yml
+++ b/.github/workflows/pr-status-update.yml
@@ -24,391 +24,174 @@ jobs:
     name: Update Issue Status
     runs-on: ubuntu-latest
     environment: project
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Update Issue Status
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run pr-status command
+        id: pr-status
+        env:
+          PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          # Run hewg pr-status command with JSON output
+          # stdout = JSON result, stderr = Deno messages (displayed in workflow log)
+          set +e  # Temporarily disable exit on error
+
+          # Build command arguments
+          draft_flag=""
+          if [ "${{ github.event.pull_request.draft }}" = "true" ]; then
+            draft_flag="--draft"
+          fi
+
+          # Use heredoc for body to handle special characters
+          body_content='${{ github.event.pull_request.body }}'
+
+          result=$(deno run --allow-read --allow-env --allow-net src/main.ts pr-status \
+            --pr-number "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --branch "${{ github.head_ref }}" \
+            --body "$body_content" \
+            $draft_flag \
+            --config ".github/project.toml" \
+            --json)
+          exit_code=$?
+          set -e  # Re-enable exit on error
+
+          echo "::group::CLI Output"
+          echo "$result"
+          echo "::endgroup::"
+
+          # Check if command succeeded
+          if [ $exit_code -ne 0 ]; then
+            echo "::error::CLI exited with code $exit_code"
+            echo "result=$result" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          # Validate JSON before parsing
+          if ! echo "$result" | jq -e . > /dev/null 2>&1; then
+            echo "::error::Invalid JSON output from CLI"
+            echo "Raw output: $result"
+            exit 1
+          fi
+
+          echo "result=$result" >> $GITHUB_OUTPUT
+
+          # Parse result safely with defaults
+          success=$(echo "$result" | jq -r '.success // "false"')
+          skipped_draft=$(echo "$result" | jq -r '.skippedDraft // "false"')
+
+          # Handle skipped draft case
+          if [ "$skipped_draft" = "true" ]; then
+            echo "::notice::Skipped draft PR (ignore_draft is enabled)"
+            exit 0
+          fi
+
+          if [ "$success" != "true" ]; then
+            error=$(echo "$result" | jq -r '.error // "Unknown error"')
+            context=$(echo "$result" | jq -r '.context // empty')
+            echo "::error::PR-status failed: $error"
+            if [ -n "$context" ]; then
+              echo "Context: $context"
+            fi
+            exit 1
+          fi
+
+          # Extract values for logging/comment
+          echo "processed_issues=$(echo "$result" | jq -r '.processedIssues // [] | map("#" + tostring) | join(", ")')" >> $GITHUB_OUTPUT
+          echo "failed_issues=$(echo "$result" | jq -r '.failedIssues // [] | map("#" + tostring) | join(", ")')" >> $GITHUB_OUTPUT
+          echo "new_status=$(echo "$result" | jq -r '.newStatus // ""')" >> $GITHUB_OUTPUT
+          echo "processed_count=$(echo "$result" | jq -r '.processedIssues | length')" >> $GITHUB_OUTPUT
+          echo "failed_count=$(echo "$result" | jq -r '.failedIssues | length')" >> $GITHUB_OUTPUT
+
+      - name: Log success
+        if: steps.pr-status.outputs.processed_count != '0'
+        run: |
+          echo "✓ Updated status to '${{ steps.pr-status.outputs.new_status }}' for issues: ${{ steps.pr-status.outputs.processed_issues }}"
+          if [ -n "${{ steps.pr-status.outputs.failed_issues }}" ]; then
+            echo "✗ Failed to update: ${{ steps.pr-status.outputs.failed_issues }}"
+          fi
+
+      - name: Comment on PR (no issues found)
+        if: steps.pr-status.outputs.processed_count == '0' && steps.pr-status.outputs.failed_count == '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branchName = '${{ github.head_ref }}';
+            const prBody = `${{ github.event.pull_request.body }}`;
+            const hasBody = prBody && prBody.trim().length > 0;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                ':information_source: **No linked Issues found**',
+                '',
+                'Could not find Issue numbers in:',
+                `- Branch name: \`${branchName}\``,
+                `- PR body keywords: ${hasBody ? '(none matching)' : '(empty)'}`,
+                '',
+                '**Expected formats**:',
+                '- Branch: `label/author/{issue_number}/title`',
+                '- Keywords: `Closes #N`, `Fixes #N`, `Resolves #N`'
+              ].join('\n')
+            });
+
+      - name: Handle partial failure
+        if: steps.pr-status.outputs.failed_count != '0' && steps.pr-status.outputs.processed_count != '0'
         uses: actions/github-script@v7
         env:
           PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
-            const fs = require('fs');
-
-            // Simple TOML parser for our specific use case
-            function parseToml(content) {
-              const result = { project: {}, defaults: {}, pr: {} };
-              let currentSection = null;
-
-              for (const line of content.split('\n')) {
-                const trimmed = line.trim();
-
-                // Skip empty lines and comments
-                if (!trimmed || trimmed.startsWith('#')) continue;
-
-                // Section header
-                const sectionMatch = trimmed.match(/^\[(\w+)\]$/);
-                if (sectionMatch) {
-                  currentSection = sectionMatch[1];
-                  if (!result[currentSection]) result[currentSection] = {};
-                  continue;
-                }
-
-                // Key-value pair
-                const kvMatch = trimmed.match(/^(\w+)\s*=\s*(.+)$/);
-                if (kvMatch && currentSection) {
-                  let value = kvMatch[2].trim();
-                  // Remove quotes from strings
-                  if ((value.startsWith('"') && value.endsWith('"')) ||
-                      (value.startsWith("'") && value.endsWith("'"))) {
-                    value = value.slice(1, -1);
-                  }
-                  // Parse booleans
-                  else if (value === 'true') {
-                    value = true;
-                  }
-                  else if (value === 'false') {
-                    value = false;
-                  }
-                  // Parse numbers
-                  else if (/^\d+$/.test(value)) {
-                    value = parseInt(value, 10);
-                  }
-                  else if (/^\d+\.\d+$/.test(value)) {
-                    value = parseFloat(value);
-                  }
-                  result[currentSection][kvMatch[1]] = value;
-                }
-              }
-
-              return result;
-            }
-
-            // Parse project URL to extract owner and number
-            function parseProjectUrl(url) {
-              const userMatch = url.match(/github\.com\/users\/([^/]+)\/projects\/(\d+)/);
-              if (userMatch) {
-                return { owner: userMatch[1], number: parseInt(userMatch[2], 10), isOrg: false };
-              }
-              const orgMatch = url.match(/github\.com\/orgs\/([^/]+)\/projects\/(\d+)/);
-              if (orgMatch) {
-                return { owner: orgMatch[1], number: parseInt(orgMatch[2], 10), isOrg: true };
-              }
-              throw new Error(`Invalid project URL: ${url}`);
-            }
-
-            // Extract Issue numbers from branch name
-            function extractFromBranch(branchName, pattern) {
-              try {
-                const regex = new RegExp(pattern);
-                const match = branchName.match(regex);
-                if (match && match[1]) {
-                  const num = parseInt(match[1], 10);
-                  if (num > 0) return [num];
-                }
-              } catch (e) {
-                console.log(`Warning: Invalid branch pattern: ${pattern}`);
-              }
-              return [];
-            }
-
-            // Extract Issue numbers from PR body using keywords
-            function extractFromBody(body) {
-              if (!body) return [];
-              const regex = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
-              const issues = [];
-              let match;
-              while ((match = regex.exec(body)) !== null) {
-                const num = parseInt(match[1], 10);
-                if (num > 0 && !issues.includes(num)) {
-                  issues.push(num);
-                }
-              }
-              return issues;
-            }
-
-            // Comment on PR with message
-            async function commentOnPR(message) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body: message
-              });
-            }
-
-            // Comment on PR with error message
-            async function commentError(message, runUrl, processedIssues = [], failedIssues = []) {
-              let body = `:warning: **Failed to update Issue status**\n\n**Error**: ${message}\n\n`;
-
-              if (processedIssues.length > 0) {
-                body += `**Issues processed**: ${processedIssues.map(i => `#${i}`).join(', ')}\n`;
-              }
-              if (failedIssues.length > 0) {
-                body += `**Issues failed**: ${failedIssues.map(i => `#${i}`).join(', ')}\n`;
-              }
-
-              body += `\n**Troubleshooting**:\n- Ensure \`PROJECT_TOKEN\` secret is configured with \`project\` scope\n- Verify the project URL in \`.github/project.toml\`\n- Check that the status option "${config?.pr?.review_status || 'In Review'}" exists in your project\n\n[View workflow run](${runUrl})`;
-
-              await commentOnPR(body);
-            }
-
-            // Comment warning when no Issues found
-            async function commentNoIssuesFound(branchName, prBody) {
-              const body = `:information_source: **No linked Issues found**\n\nCould not find Issue numbers in:\n- Branch name: \`${branchName}\`\n- PR body keywords: ${prBody ? '(none matching)' : '(empty)'}\n\n**Expected formats**:\n- Branch: \`label/author/{issue_number}/title\`\n- Keywords: \`Closes #N\`, \`Fixes #N\`, \`Resolves #N\``;
-
-              await commentOnPR(body);
-            }
-
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            let config;
+            const processed = '${{ steps.pr-status.outputs.processed_issues }}';
+            const failed = '${{ steps.pr-status.outputs.failed_issues }}';
 
-            try {
-              // Read and parse config
-              const configPath = '.github/project.toml';
-              if (!fs.existsSync(configPath)) {
-                throw new Error(`Configuration file not found: ${configPath}`);
-              }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                ':warning: **Partial success updating Issue status**',
+                '',
+                `**Successfully updated**: ${processed}`,
+                `**Failed**: ${failed}`,
+                '',
+                `[View workflow run](${runUrl})`
+              ].join('\n')
+            });
 
-              const configContent = fs.readFileSync(configPath, 'utf8');
-              config = parseToml(configContent);
+      - name: Handle failure
+        if: failure()
+        uses: actions/github-script@v7
+        env:
+          PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
-              if (!config.project?.url) {
-                throw new Error('project.url is required in configuration');
-              }
-
-              // Get PR config with defaults
-              const prConfig = {
-                review_status: config.pr?.review_status || 'In Review',
-                branch_pattern: config.pr?.branch_pattern || '^[^/]+/[^/]+/(\\d+)/.*$',
-                ignore_draft: config.pr?.ignore_draft || false
-              };
-
-              const pr = context.payload.pull_request;
-
-              // Check if Draft PR should be ignored
-              if (prConfig.ignore_draft && pr.draft) {
-                console.log('Skipping Draft PR (ignore_draft is enabled)');
-                return;
-              }
-
-              // Extract Issue numbers
-              const branchName = pr.head.ref;
-              const prBody = pr.body || '';
-
-              const branchIssues = extractFromBranch(branchName, prConfig.branch_pattern);
-              const bodyIssues = extractFromBody(prBody);
-
-              // Combine and deduplicate
-              const allIssues = [...new Set([...branchIssues, ...bodyIssues])];
-
-              console.log(`Branch: ${branchName}`);
-              console.log(`Issues from branch: ${branchIssues.join(', ') || 'none'}`);
-              console.log(`Issues from body: ${bodyIssues.join(', ') || 'none'}`);
-              console.log(`All Issues to process: ${allIssues.join(', ') || 'none'}`);
-
-              if (allIssues.length === 0) {
-                await commentNoIssuesFound(branchName, prBody);
-                console.log('No Issue numbers found, commented on PR');
-                return;
-              }
-
-              // Parse project URL
-              const projectInfo = parseProjectUrl(config.project.url);
-              console.log(`Project: ${projectInfo.owner}/${projectInfo.number}`);
-
-              // Get project ID and fields
-              const projectQuery = projectInfo.isOrg ? `
-                query($owner: String!, $number: Int!) {
-                  organization(login: $owner) {
-                    projectV2(number: $number) {
-                      id
-                      title
-                      fields(first: 20) {
-                        nodes {
-                          ... on ProjectV2Field {
-                            id
-                            name
-                          }
-                          ... on ProjectV2SingleSelectField {
-                            id
-                            name
-                            options {
-                              id
-                              name
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              ` : `
-                query($owner: String!, $number: Int!) {
-                  user(login: $owner) {
-                    projectV2(number: $number) {
-                      id
-                      title
-                      fields(first: 20) {
-                        nodes {
-                          ... on ProjectV2Field {
-                            id
-                            name
-                          }
-                          ... on ProjectV2SingleSelectField {
-                            id
-                            name
-                            options {
-                              id
-                              name
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              `;
-
-              const projectResult = await github.graphql(projectQuery, {
-                owner: projectInfo.owner,
-                number: projectInfo.number
-              });
-
-              const project = projectInfo.isOrg
-                ? projectResult.organization?.projectV2
-                : projectResult.user?.projectV2;
-
-              if (!project) {
-                throw new Error(`Project not found: ${config.project.url}`);
-              }
-
-              console.log(`Found project: ${project.title} (${project.id})`);
-
-              // Find Status field and option
-              const statusField = project.fields.nodes.find(f => f.name?.toLowerCase() === 'status');
-              if (!statusField) {
-                throw new Error('Status field not found in project');
-              }
-
-              const statusOption = statusField.options?.find(
-                o => o.name?.toLowerCase() === prConfig.review_status.toLowerCase()
-              );
-              if (!statusOption) {
-                throw new Error(`Status option "${prConfig.review_status}" not found. Available: ${statusField.options?.map(o => o.name).join(', ')}`);
-              }
-
-              console.log(`Status field: ${statusField.id}, Option: ${statusOption.name} (${statusOption.id})`);
-
-              // Process each Issue
-              const processedIssues = [];
-              const failedIssues = [];
-
-              for (const issueNumber of allIssues) {
-                try {
-                  console.log(`\nProcessing Issue #${issueNumber}...`);
-
-                  // Get Issue node ID
-                  const issueResult = await github.rest.issues.get({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: issueNumber
-                  });
-
-                  const issueNodeId = issueResult.data.node_id;
-                  console.log(`Issue node ID: ${issueNodeId}`);
-
-                  // Check if Issue is already in project
-                  const itemsQuery = `
-                    query($projectId: ID!) {
-                      node(id: $projectId) {
-                        ... on ProjectV2 {
-                          items(first: 100) {
-                            nodes {
-                              id
-                              content {
-                                ... on Issue {
-                                  id
-                                  number
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  `;
-
-                  const itemsResult = await github.graphql(itemsQuery, { projectId: project.id });
-                  const items = itemsResult.node?.items?.nodes || [];
-                  let projectItem = items.find(item => item.content?.number === issueNumber);
-
-                  if (!projectItem) {
-                    // Add Issue to project
-                    console.log(`Issue #${issueNumber} not in project, adding...`);
-
-                    const addResult = await github.graphql(`
-                      mutation($projectId: ID!, $contentId: ID!) {
-                        addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
-                          item {
-                            id
-                          }
-                        }
-                      }
-                    `, {
-                      projectId: project.id,
-                      contentId: issueNodeId
-                    });
-
-                    projectItem = { id: addResult.addProjectV2ItemById.item.id };
-                    console.log(`Added Issue #${issueNumber} to project, item ID: ${projectItem.id}`);
-                  } else {
-                    console.log(`Issue #${issueNumber} already in project, item ID: ${projectItem.id}`);
-                  }
-
-                  // Update Status
-                  await github.graphql(`
-                    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
-                      updateProjectV2ItemFieldValue(
-                        input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: {singleSelectOptionId: $value}}
-                      ) { projectV2Item { id } }
-                    }
-                  `, {
-                    projectId: project.id,
-                    itemId: projectItem.id,
-                    fieldId: statusField.id,
-                    value: statusOption.id
-                  });
-
-                  console.log(`Updated Issue #${issueNumber} status to: ${prConfig.review_status}`);
-                  processedIssues.push(issueNumber);
-
-                } catch (issueError) {
-                  console.error(`Error processing Issue #${issueNumber}: ${issueError.message}`);
-                  failedIssues.push(issueNumber);
-                }
-              }
-
-              // Summary
-              console.log(`\n=== Summary ===`);
-              console.log(`Processed: ${processedIssues.length} issues`);
-              console.log(`Failed: ${failedIssues.length} issues`);
-
-              if (failedIssues.length > 0 && processedIssues.length > 0) {
-                // Partial success
-                await commentOnPR(`:warning: **Partial success updating Issue status**\n\n**Successfully updated**: ${processedIssues.map(i => `#${i}`).join(', ')}\n**Failed**: ${failedIssues.map(i => `#${i}`).join(', ')}\n\n[View workflow run](${runUrl})`);
-              } else if (failedIssues.length > 0) {
-                // All failed
-                await commentError('Failed to process all Issues', runUrl, [], failedIssues);
-                core.setFailed('Failed to process all Issues');
-              } else {
-                console.log('All Issues processed successfully');
-              }
-
-            } catch (error) {
-              console.error(`Error: ${error.message}`);
-              await commentError(error.message, runUrl);
-              core.setFailed(error.message);
-            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                ':warning: **Failed to update Issue status**',
+                '',
+                '**Troubleshooting**:',
+                '- Ensure `PROJECT_TOKEN` secret is configured with `project` scope',
+                '- Verify the project URL in `.github/project.toml`',
+                '- Check that the status option exists in your project',
+                '',
+                `[View workflow run](${runUrl})`
+              ].join('\n')
+            });

--- a/docs/design/issue-#13-refactor-workflow-cli-commands.md
+++ b/docs/design/issue-#13-refactor-workflow-cli-commands.md
@@ -1,0 +1,372 @@
+# Design Document: Refactor Workflow CLI Commands
+
+**Issue**: #13
+**Date**: 2026-01-07
+**Status**: Draft
+
+## Overview
+
+This document describes the architecture and design for refactoring `issue-to-project.yml` and `pr-status-update.yml` workflow files to use hewg CLI commands (`link-issue`, `pr-status`) instead of embedded JavaScript.
+
+## Goals
+
+1. Move business logic from GitHub Actions workflows to hewg CLI
+2. Reduce workflow file complexity and duplication
+3. Enable testing of project integration logic
+4. Maintain consistency with `auto-tag` command pattern
+
+## Architecture
+
+### System Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    GitHub Actions Workflow                   │
+├─────────────────────────────────────────────────────────────┤
+│  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐     │
+│  │ Checkout    │ -> │ Setup Deno  │ -> │ Run hewg    │     │
+│  └─────────────┘    └─────────────┘    │ CLI command │     │
+│                                         └──────┬──────┘     │
+│                                                │             │
+│                                         JSON output          │
+│                                                │             │
+│                                         ┌──────▼──────┐     │
+│                                         │ Parse JSON  │     │
+│                                         │ & Comment   │     │
+│                                         └─────────────┘     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Module Structure
+
+```
+src/
+├── main.ts                      # CLI entry point (add new command registrations)
+├── cli/
+│   └── commands/
+│       ├── mod.ts               # Export new commands
+│       ├── link-issue.ts        # NEW: link-issue command
+│       ├── pr-status.ts         # NEW: pr-status command
+│       └── auto-tag.ts          # Existing (reference pattern)
+├── lib/
+│   └── github-project.ts        # NEW: GitHub Project GraphQL API utilities
+└── types/
+    └── project-config.ts        # Existing project config types
+```
+
+## Component Design
+
+### 1. GitHub Project API Module (`src/lib/github-project.ts`)
+
+Shared utilities for GitHub Project GraphQL operations.
+
+```typescript
+/**
+ * GitHub Project API client for GraphQL operations.
+ * Handles authentication via PROJECT_TOKEN environment variable.
+ */
+export interface GitHubProjectClient {
+  getProject(url: string): Promise<Project>;
+  addIssueToProject(projectId: string, issueNodeId: string): Promise<ProjectItem>;
+  updateItemField(params: UpdateFieldParams): Promise<void>;
+  getProjectItems(projectId: string): Promise<ProjectItem[]>;
+}
+
+export interface Project {
+  id: string;
+  title: string;
+  fields: ProjectField[];
+}
+
+export interface ProjectField {
+  id: string;
+  name: string;
+  type: 'SINGLE_SELECT' | 'ITERATION' | 'NUMBER' | 'DATE' | 'TEXT';
+  options?: { id: string; name: string }[];
+  iterations?: { id: string; title: string }[];
+}
+
+export interface ProjectItem {
+  id: string;
+  contentId: string;
+  contentType: 'Issue' | 'PullRequest';
+  issueNumber?: number;
+}
+```
+
+### 2. Link-Issue Command (`src/cli/commands/link-issue.ts`)
+
+#### Command Interface
+
+```bash
+hewg link-issue \
+  --issue-number <number> \
+  --repo <owner/repo> \
+  --config <path> \
+  [--json] \
+  [--verbose]
+```
+
+#### Flags
+
+| Flag | Short | Required | Default | Description |
+|------|-------|----------|---------|-------------|
+| `--issue-number` | `-i` | Yes | - | Issue number to add to project |
+| `--repo` | `-r` | Yes | - | Repository in owner/repo format |
+| `--config` | `-c` | No | `.github/project.toml` | Path to config file |
+| `--json` | `-j` | No | false | Output result as JSON |
+| `--verbose` | `-v` | No | false | Enable verbose logging |
+
+#### JSON Output Schema
+
+```typescript
+interface LinkIssueResult {
+  success: boolean;
+  issueNumber: number;
+  projectItemId?: string;
+  projectTitle?: string;
+  fieldsSet?: string[];
+  error?: string;
+  context?: {
+    repo: string;
+    configPath: string;
+  };
+}
+```
+
+#### Algorithm
+
+1. Read and parse TOML config
+2. Validate `project.url` exists
+3. Get issue node ID via GitHub REST API
+4. Get project ID and fields via GraphQL
+5. Add issue to project (`addProjectV2ItemById`)
+6. Set default field values from `[defaults]` section:
+   - Status (single select)
+   - Priority (single select)
+   - Iteration (iteration field)
+   - Size/Estimate (number fields)
+   - Start date/Target date (date fields)
+7. Return result JSON
+
+### 3. PR-Status Command (`src/cli/commands/pr-status.ts`)
+
+#### Command Interface
+
+```bash
+hewg pr-status \
+  --pr-number <number> \
+  --repo <owner/repo> \
+  --branch <name> \
+  [--body <text>] \
+  [--draft] \
+  --config <path> \
+  [--json] \
+  [--verbose]
+```
+
+#### Flags
+
+| Flag | Short | Required | Default | Description |
+|------|-------|----------|---------|-------------|
+| `--pr-number` | `-p` | Yes | - | Pull request number |
+| `--repo` | `-r` | Yes | - | Repository in owner/repo format |
+| `--branch` | `-b` | Yes | - | Source branch name |
+| `--body` | - | No | - | PR body text |
+| `--draft` | `-d` | No | false | Whether PR is a draft |
+| `--config` | `-c` | No | `.github/project.toml` | Path to config file |
+| `--json` | `-j` | No | false | Output result as JSON |
+| `--verbose` | `-v` | No | false | Enable verbose logging |
+
+#### JSON Output Schema
+
+```typescript
+interface PrStatusResult {
+  success: boolean;
+  prNumber: number;
+  processedIssues: number[];
+  failedIssues: number[];
+  skippedIssues: number[];
+  newStatus: string;
+  isDraft: boolean;
+  skippedDraft: boolean;
+  error?: string;
+  context?: {
+    repo: string;
+    branch: string;
+    configPath: string;
+  };
+}
+```
+
+#### Algorithm
+
+1. Read and parse TOML config
+2. Check if draft PR should be skipped (`pr.ignore_draft`)
+3. Extract issue numbers:
+   - From branch name using `pr.branch_pattern` regex
+   - From body text using keywords (Closes/Fixes/Resolves #N)
+4. For each unique issue number:
+   - Get issue node ID
+   - Check if issue is in project
+   - If not, add to project
+   - Update Status field to `pr.review_status` (default: "In Review")
+5. Return aggregated result JSON
+
+### 4. Issue Number Extraction
+
+```typescript
+/**
+ * Extract issue numbers from branch name using configurable pattern.
+ * Default pattern: ^[^/]+/[^/]+/(\d+)/.*$
+ * Example: feature/alice/123/add-auth -> [123]
+ */
+export function extractFromBranch(branchName: string, pattern: string): number[];
+
+/**
+ * Extract issue numbers from PR body using GitHub keywords.
+ * Keywords: close[sd], fix(e[sd])?, resolve[sd]
+ * Example: "Fixes #123, Closes #456" -> [123, 456]
+ */
+export function extractFromBody(body: string): number[];
+```
+
+## Configuration
+
+### project.toml Schema
+
+```toml
+[project]
+url = "https://github.com/users/username/projects/1"
+
+[defaults]
+status = "Todo"
+priority = "Medium"
+# iteration = "Sprint 1"
+# size = 3
+# estimate = 5
+# start_date = "2026-01-01"
+# target_date = "2026-01-15"
+
+[pr]
+review_status = "In Review"
+branch_pattern = "^[^/]+/[^/]+/(\\d+)/.*$"
+ignore_draft = false
+```
+
+## Error Handling
+
+### Error Types
+
+| Error | Exit Code | Handling |
+|-------|-----------|----------|
+| Config file not found | 1 | Return error in JSON, workflow comments on issue |
+| Invalid project URL | 1 | Return error in JSON |
+| Issue not found | 1 | Return error in JSON |
+| Project not found | 1 | Return error in JSON |
+| API authentication failed | 1 | Return error in JSON |
+| Field option not found | 0 | Log warning, continue with other fields |
+
+### Error Output Format
+
+```json
+{
+  "success": false,
+  "error": "Project not found: https://github.com/...",
+  "context": {
+    "repo": "owner/repo",
+    "configPath": ".github/project.toml"
+  }
+}
+```
+
+## Authentication
+
+Environment variable: `PROJECT_TOKEN`
+
+Required scopes:
+- `project` - For GitHub Project access
+- `repo` - For issue/PR access (usually included)
+
+The CLI reads the token from environment variable and passes it to GraphQL requests via Authorization header.
+
+## Workflow Integration
+
+### issue-to-project.yml (After Refactoring)
+
+```yaml
+- name: Run link-issue command
+  id: link-issue
+  env:
+    PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+  run: |
+    result=$(deno run --allow-read --allow-env --allow-net \
+      src/main.ts link-issue \
+      --issue-number "${{ github.event.issue.number }}" \
+      --repo "${{ github.repository }}" \
+      --config ".github/project.toml" \
+      --json)
+    echo "result=$result" >> $GITHUB_OUTPUT
+```
+
+### pr-status-update.yml (After Refactoring)
+
+```yaml
+- name: Run pr-status command
+  id: pr-status
+  env:
+    PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+  run: |
+    result=$(deno run --allow-read --allow-env --allow-net \
+      src/main.ts pr-status \
+      --pr-number "${{ github.event.pull_request.number }}" \
+      --repo "${{ github.repository }}" \
+      --branch "${{ github.head_ref }}" \
+      --body "${{ github.event.pull_request.body }}" \
+      ${{ github.event.pull_request.draft && '--draft' || '' }} \
+      --config ".github/project.toml" \
+      --json)
+    echo "result=$result" >> $GITHUB_OUTPUT
+```
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **Issue extraction tests**
+   - `extractFromBranch()` with various patterns
+   - `extractFromBody()` with various keyword formats
+
+2. **Config parsing tests**
+   - Valid TOML parsing
+   - Missing optional fields
+   - Invalid project URL
+
+3. **JSON output tests**
+   - Success result format
+   - Error result format
+
+### Integration Tests (Manual)
+
+1. Create test issue, verify it's added to project
+2. Create PR with issue reference, verify status update
+3. Test with draft PR and `ignore_draft` setting
+
+## Security Considerations
+
+1. **Token handling**: Never log or include token in error messages
+2. **Input validation**: Validate issue/PR numbers are positive integers
+3. **URL validation**: Validate project URL format before making requests
+4. **Rate limiting**: Respect GitHub API rate limits (not implemented in MVP)
+
+## Dependencies
+
+- `@std/fmt/colors` - Terminal color output
+- Deno built-in `fetch` - HTTP requests for GraphQL API
+
+## Future Enhancements
+
+1. Caching project field metadata
+2. Batch processing for multiple issues
+3. Dry-run mode for testing
+4. Support for organization projects vs user projects detection

--- a/docs/design/issue-#13-refactor-workflow-cli-commands.md
+++ b/docs/design/issue-#13-refactor-workflow-cli-commands.md
@@ -109,13 +109,13 @@ hewg link-issue \
 
 #### Flags
 
-| Flag | Short | Required | Default | Description |
-|------|-------|----------|---------|-------------|
-| `--issue-number` | `-i` | Yes | - | Issue number to add to project |
-| `--repo` | `-r` | Yes | - | Repository in owner/repo format |
-| `--config` | `-c` | No | `.github/project.toml` | Path to config file |
-| `--json` | `-j` | No | false | Output result as JSON |
-| `--verbose` | `-v` | No | false | Enable verbose logging |
+| Flag             | Short | Required | Default                | Description                     |
+| ---------------- | ----- | -------- | ---------------------- | ------------------------------- |
+| `--issue-number` | `-i`  | Yes      | -                      | Issue number to add to project  |
+| `--repo`         | `-r`  | Yes      | -                      | Repository in owner/repo format |
+| `--config`       | `-c`  | No       | `.github/project.toml` | Path to config file             |
+| `--json`         | `-j`  | No       | false                  | Output result as JSON           |
+| `--verbose`      | `-v`  | No       | false                  | Enable verbose logging          |
 
 #### JSON Output Schema
 
@@ -167,16 +167,16 @@ hewg pr-status \
 
 #### Flags
 
-| Flag | Short | Required | Default | Description |
-|------|-------|----------|---------|-------------|
-| `--pr-number` | `-p` | Yes | - | Pull request number |
-| `--repo` | `-r` | Yes | - | Repository in owner/repo format |
-| `--branch` | `-b` | Yes | - | Source branch name |
-| `--body` | - | No | - | PR body text |
-| `--draft` | `-d` | No | false | Whether PR is a draft |
-| `--config` | `-c` | No | `.github/project.toml` | Path to config file |
-| `--json` | `-j` | No | false | Output result as JSON |
-| `--verbose` | `-v` | No | false | Enable verbose logging |
+| Flag          | Short | Required | Default                | Description                     |
+| ------------- | ----- | -------- | ---------------------- | ------------------------------- |
+| `--pr-number` | `-p`  | Yes      | -                      | Pull request number             |
+| `--repo`      | `-r`  | Yes      | -                      | Repository in owner/repo format |
+| `--branch`    | `-b`  | Yes      | -                      | Source branch name              |
+| `--body`      | -     | No       | -                      | PR body text                    |
+| `--draft`     | `-d`  | No       | false                  | Whether PR is a draft           |
+| `--config`    | `-c`  | No       | `.github/project.toml` | Path to config file             |
+| `--json`      | `-j`  | No       | false                  | Output result as JSON           |
+| `--verbose`   | `-v`  | No       | false                  | Enable verbose logging          |
 
 #### JSON Output Schema
 
@@ -258,14 +258,14 @@ ignore_draft = false
 
 ### Error Types
 
-| Error | Exit Code | Handling |
-|-------|-----------|----------|
-| Config file not found | 1 | Return error in JSON, workflow comments on issue |
-| Invalid project URL | 1 | Return error in JSON |
-| Issue not found | 1 | Return error in JSON |
-| Project not found | 1 | Return error in JSON |
-| API authentication failed | 1 | Return error in JSON |
-| Field option not found | 0 | Log warning, continue with other fields |
+| Error                     | Exit Code | Handling                                         |
+| ------------------------- | --------- | ------------------------------------------------ |
+| Config file not found     | 1         | Return error in JSON, workflow comments on issue |
+| Invalid project URL       | 1         | Return error in JSON                             |
+| Issue not found           | 1         | Return error in JSON                             |
+| Project not found         | 1         | Return error in JSON                             |
+| API authentication failed | 1         | Return error in JSON                             |
+| Field option not found    | 0         | Log warning, continue with other fields          |
 
 ### Error Output Format
 
@@ -285,6 +285,7 @@ ignore_draft = false
 Environment variable: `PROJECT_TOKEN`
 
 Required scopes:
+
 - `project` - For GitHub Project access
 - `repo` - For issue/PR access (usually included)
 

--- a/docs/workflow/issue-#13-refactor-workflow-cli-commands.md
+++ b/docs/workflow/issue-#13-refactor-workflow-cli-commands.md
@@ -5,13 +5,13 @@
 
 ## Phase Overview
 
-| Phase | Description | Dependencies |
-|-------|-------------|--------------|
-| 1 | Create GitHub Project API module | None |
-| 2 | Implement link-issue command | Phase 1 |
-| 3 | Implement pr-status command | Phase 1 |
-| 4 | Update workflow files | Phase 2, 3 |
-| 5 | Testing and validation | Phase 4 |
+| Phase | Description                      | Dependencies |
+| ----- | -------------------------------- | ------------ |
+| 1     | Create GitHub Project API module | None         |
+| 2     | Implement link-issue command     | Phase 1      |
+| 3     | Implement pr-status command      | Phase 1      |
+| 4     | Update workflow files            | Phase 2, 3   |
+| 5     | Testing and validation           | Phase 4      |
 
 ## Phase 1: GitHub Project API Module
 

--- a/docs/workflow/issue-#13-refactor-workflow-cli-commands.md
+++ b/docs/workflow/issue-#13-refactor-workflow-cli-commands.md
@@ -1,0 +1,220 @@
+# Implementation Workflow: Refactor Workflow CLI Commands
+
+**Issue**: #13
+**Date**: 2026-01-07
+
+## Phase Overview
+
+| Phase | Description | Dependencies |
+|-------|-------------|--------------|
+| 1 | Create GitHub Project API module | None |
+| 2 | Implement link-issue command | Phase 1 |
+| 3 | Implement pr-status command | Phase 1 |
+| 4 | Update workflow files | Phase 2, 3 |
+| 5 | Testing and validation | Phase 4 |
+
+## Phase 1: GitHub Project API Module
+
+### Tasks
+
+- [ ] Create `src/lib/github-project.ts`
+- [ ] Implement `parseProjectUrl()` function
+- [ ] Implement `createGitHubProjectClient()` factory
+- [ ] Implement GraphQL query functions:
+  - [ ] `getProject()` - Get project ID and fields
+  - [ ] `addIssueToProject()` - Add issue to project
+  - [ ] `updateItemField()` - Update field value
+  - [ ] `getProjectItems()` - List project items
+- [ ] Implement `getIssueNodeId()` - Get issue node ID via REST API
+
+### Files to Create/Modify
+
+```
+src/lib/github-project.ts  (NEW)
+src/lib/mod.ts             (NEW - export module)
+```
+
+### Commit Message
+
+```
+✨ feat: add GitHub Project API module
+
+- Add GraphQL client for GitHub Projects V2
+- Implement project/field/item operations
+- Support both user and organization projects
+```
+
+## Phase 2: Link-Issue Command
+
+### Tasks
+
+- [ ] Create `src/cli/commands/link-issue.ts`
+- [ ] Define command flags and options
+- [ ] Implement `linkIssueAction()`:
+  - [ ] Read and validate config
+  - [ ] Get project info via GraphQL
+  - [ ] Add issue to project
+  - [ ] Set default field values
+  - [ ] Return JSON result
+- [ ] Export from `src/cli/commands/mod.ts`
+- [ ] Register in `src/main.ts`
+- [ ] Add unit tests for issue extraction logic
+
+### Files to Create/Modify
+
+```
+src/cli/commands/link-issue.ts  (NEW)
+src/cli/commands/mod.ts         (MODIFY - add export)
+src/main.ts                     (MODIFY - register command)
+tests/link-issue_test.ts        (NEW)
+```
+
+### Commit Message
+
+```
+✨ feat: add link-issue command
+
+- Add command to link issues to GitHub Projects
+- Support default field values from config
+- JSON output for workflow integration
+```
+
+## Phase 3: PR-Status Command
+
+### Tasks
+
+- [ ] Create `src/cli/commands/pr-status.ts`
+- [ ] Define command flags and options
+- [ ] Implement issue number extraction:
+  - [ ] `extractFromBranch()` with configurable pattern
+  - [ ] `extractFromBody()` for GitHub keywords
+- [ ] Implement `prStatusAction()`:
+  - [ ] Read and validate config
+  - [ ] Check draft PR handling
+  - [ ] Extract and deduplicate issue numbers
+  - [ ] Process each issue (add to project, update status)
+  - [ ] Return aggregated JSON result
+- [ ] Export from `src/cli/commands/mod.ts`
+- [ ] Register in `src/main.ts`
+- [ ] Add unit tests for extraction logic
+
+### Files to Create/Modify
+
+```
+src/cli/commands/pr-status.ts   (NEW)
+src/cli/commands/mod.ts         (MODIFY - add export)
+src/main.ts                     (MODIFY - register command)
+tests/pr-status_test.ts         (NEW)
+```
+
+### Commit Message
+
+```
+✨ feat: add pr-status command
+
+- Add command to update issue status on PR events
+- Extract issue numbers from branch and body
+- Support draft PR skipping
+- JSON output for workflow integration
+```
+
+## Phase 4: Update Workflow Files
+
+### Tasks
+
+- [ ] Update `issue-to-project.yml`:
+  - [ ] Remove inline JavaScript
+  - [ ] Add Deno setup step
+  - [ ] Call `hewg link-issue` command
+  - [ ] Parse JSON and comment on issue
+  - [ ] Handle errors with failure comment
+- [ ] Update `pr-status-update.yml`:
+  - [ ] Remove inline JavaScript
+  - [ ] Add Deno setup step
+  - [ ] Call `hewg pr-status` command
+  - [ ] Parse JSON and comment on PR
+  - [ ] Handle errors with failure comment
+- [ ] Update template files in `src/templates/`
+
+### Files to Modify
+
+```
+.github/workflows/issue-to-project.yml     (MODIFY)
+.github/workflows/pr-status-update.yml     (MODIFY)
+src/templates/issue-to-project.yml         (MODIFY)
+src/templates/pr-status-update.yml         (MODIFY)
+```
+
+### Commit Messages
+
+```
+♻️ refactor: update issue-to-project workflow to use CLI
+
+- Replace inline JavaScript with hewg link-issue command
+- Simplify workflow structure
+- Maintain same functionality and error handling
+
+♻️ refactor: update pr-status-update workflow to use CLI
+
+- Replace inline JavaScript with hewg pr-status command
+- Simplify workflow structure
+- Maintain same functionality and error handling
+```
+
+## Phase 5: Testing and Validation
+
+### Tasks
+
+- [ ] Run `deno fmt` and `deno lint`
+- [ ] Run `deno check **/*.ts`
+- [ ] Run full test suite with coverage
+- [ ] Manual testing:
+  - [ ] Test link-issue with mock data
+  - [ ] Test pr-status with various branch patterns
+  - [ ] Test error scenarios
+
+### Commands
+
+```bash
+# Format and lint
+deno fmt
+deno lint
+
+# Type check
+deno check src/**/*.ts
+
+# Run tests with coverage
+deno test --allow-read --allow-env --coverage=coverage/
+
+# Generate coverage report
+deno coverage coverage/ --lcov > coverage/lcov.info
+```
+
+### Commit Message
+
+```
+✅ test: add tests for link-issue and pr-status commands
+
+- Add unit tests for issue extraction
+- Add config parsing tests
+- Achieve coverage targets
+```
+
+## Rollback Plan
+
+If issues are discovered after deployment:
+
+1. **Workflow rollback**: Revert workflow files to previous inline JavaScript version
+2. **CLI commands**: Can remain in codebase (unused by workflows)
+3. **No data migration needed**: Commands operate on existing GitHub Project data
+
+## Definition of Done
+
+- [ ] All unit tests passing
+- [ ] No lint errors
+- [ ] No type errors
+- [ ] Design document committed
+- [ ] Workflow document committed
+- [ ] All code reviewed and committed
+- [ ] Workflow files updated and simplified
+- [ ] JSON output matches expected schema

--- a/src/cli/commands/link-issue.ts
+++ b/src/cli/commands/link-issue.ts
@@ -1,0 +1,482 @@
+/**
+ * Link-issue command for adding issues to GitHub Projects
+ *
+ * This command adds an issue to a GitHub Project and sets default field values
+ * based on the configuration in project.toml.
+ *
+ * Used by GitHub Actions to automatically link issues to projects.
+ *
+ * @module
+ */
+
+import type { Command, CommandContext } from '../types.ts';
+import * as colors from '../colors.ts';
+import {
+  addIssueToProject,
+  findField,
+  findIteration,
+  findOption,
+  getGitHubToken,
+  getIssueNodeId,
+  getProject,
+  updateItemField,
+} from '../../lib/github-project.ts';
+
+/**
+ * Result of the link-issue operation
+ */
+interface LinkIssueResult {
+  success: boolean;
+  issueNumber: number;
+  projectItemId?: string;
+  projectTitle?: string;
+  fieldsSet?: string[];
+  error?: string;
+  context?: {
+    repo: string;
+    configPath: string;
+  };
+}
+
+/**
+ * Parsed configuration for defaults section
+ */
+interface DefaultsConfig {
+  status?: string;
+  priority?: string;
+  iteration?: string;
+  size?: number;
+  estimate?: number;
+  startDate?: string;
+  targetDate?: string;
+}
+
+/**
+ * Log a debug message to stderr (to not interfere with JSON output on stdout)
+ */
+function debugLog(message: string, verbose: boolean, jsonOutput: boolean): void {
+  if (verbose && !jsonOutput) {
+    console.error(colors.muted(`[DEBUG] ${message}`));
+  }
+}
+
+/**
+ * Parse a TOML file content (simple parser for our use case)
+ */
+function parseToml(content: string): Record<string, Record<string, unknown>> {
+  const result: Record<string, Record<string, unknown>> = {};
+  let currentSection: string | null = null;
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+
+    // Skip empty lines and comments
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    // Section header
+    const sectionMatch = trimmed.match(/^\[(\w+)\]$/);
+    if (sectionMatch) {
+      currentSection = sectionMatch[1];
+      if (!result[currentSection]) result[currentSection] = {};
+      continue;
+    }
+
+    // Key-value pair
+    const kvMatch = trimmed.match(/^(\w+)\s*=\s*(.+)$/);
+    if (kvMatch && currentSection) {
+      const rawValue = kvMatch[2].trim();
+      let value: unknown = rawValue;
+
+      // Remove quotes from strings
+      if (
+        (rawValue.startsWith('"') && rawValue.endsWith('"')) ||
+        (rawValue.startsWith("'") && rawValue.endsWith("'"))
+      ) {
+        value = rawValue.slice(1, -1);
+      } // Parse arrays
+      else if (rawValue.startsWith('[') && rawValue.endsWith(']')) {
+        try {
+          value = JSON.parse(rawValue.replace(/'/g, '"'));
+        } catch {
+          value = rawValue
+            .slice(1, -1)
+            .split(',')
+            .map((s: string) => s.trim().replace(/^["']|["']$/g, ''))
+            .filter((s: string) => s);
+        }
+      } // Parse booleans
+      else if (rawValue === 'true') {
+        value = true;
+      } else if (rawValue === 'false') {
+        value = false;
+      } // Parse numbers
+      else if (/^\d+$/.test(rawValue)) {
+        value = parseInt(rawValue, 10);
+      } else if (/^\d+\.\d+$/.test(rawValue)) {
+        value = parseFloat(rawValue);
+      }
+
+      result[currentSection][kvMatch[1]] = value;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Load project configuration from TOML file
+ */
+async function loadConfig(
+  configPath: string,
+): Promise<{ projectUrl: string; defaults: DefaultsConfig }> {
+  const content = await Deno.readTextFile(configPath);
+  const config = parseToml(content);
+
+  if (!config.project?.url) {
+    throw new Error('project.url is required in configuration');
+  }
+
+  const defaults: DefaultsConfig = {};
+  if (config.defaults) {
+    defaults.status = config.defaults.status as string | undefined;
+    defaults.priority = config.defaults.priority as string | undefined;
+    defaults.iteration = config.defaults.iteration as string | undefined;
+    defaults.size = config.defaults.size as number | undefined;
+    defaults.estimate = config.defaults.estimate as number | undefined;
+    defaults.startDate = config.defaults.start_date as string | undefined;
+    defaults.targetDate = config.defaults.target_date as string | undefined;
+  }
+
+  return {
+    projectUrl: config.project.url as string,
+    defaults,
+  };
+}
+
+/**
+ * Action handler for the link-issue command
+ */
+async function linkIssueAction(ctx: CommandContext): Promise<void> {
+  let jsonOutput = false;
+  let verbose = false;
+  let issueNumber = 0;
+  let repo = '';
+  let configPath = '.github/project.toml';
+
+  try {
+    // Extract flags
+    issueNumber = parseInt(ctx.flags['issue-number'] as string, 10);
+    repo = ctx.flags['repo'] as string;
+    configPath = (ctx.flags['config'] as string) || '.github/project.toml';
+    jsonOutput = (ctx.flags['json'] as boolean) ?? false;
+    verbose = (ctx.flags['verbose'] as boolean) ?? false;
+
+    debugLog('Starting link-issue command', verbose, jsonOutput);
+    debugLog(
+      `Flags: issue-number=${issueNumber}, repo="${repo}", config="${configPath}"`,
+      verbose,
+      jsonOutput,
+    );
+
+    // Validate required flags
+    if (!issueNumber || isNaN(issueNumber)) {
+      throw new Error('--issue-number is required and must be a valid number');
+    }
+
+    if (!repo) {
+      throw new Error('--repo is required (format: owner/repo)');
+    }
+
+    const [owner, repoName] = repo.split('/');
+    if (!owner || !repoName) {
+      throw new Error('--repo must be in the format owner/repo');
+    }
+
+    // Get GitHub token
+    debugLog('Getting GitHub token...', verbose, jsonOutput);
+    const token = getGitHubToken();
+
+    // Load configuration
+    debugLog(`Loading config from: ${configPath}`, verbose, jsonOutput);
+    const { projectUrl, defaults } = await loadConfig(configPath);
+    debugLog(`Project URL: ${projectUrl}`, verbose, jsonOutput);
+    debugLog(`Defaults: ${JSON.stringify(defaults)}`, verbose, jsonOutput);
+
+    // Get project info
+    debugLog('Fetching project information...', verbose, jsonOutput);
+    const project = await getProject(projectUrl, token);
+    debugLog(`Project: ${project.title} (${project.id})`, verbose, jsonOutput);
+
+    // Get issue node ID
+    debugLog(`Getting issue #${issueNumber} node ID...`, verbose, jsonOutput);
+    const issueNodeId = await getIssueNodeId(owner, repoName, issueNumber, token);
+    debugLog(`Issue node ID: ${issueNodeId}`, verbose, jsonOutput);
+
+    // Add issue to project
+    debugLog('Adding issue to project...', verbose, jsonOutput);
+    const itemId = await addIssueToProject(project.id, issueNodeId, token);
+    debugLog(`Project item ID: ${itemId}`, verbose, jsonOutput);
+
+    // Set default field values
+    const fieldsSet: string[] = [];
+
+    // Set Status
+    if (defaults.status) {
+      const statusField = findField(project.fields, 'Status');
+      if (statusField) {
+        const option = findOption(statusField, defaults.status);
+        if (option) {
+          debugLog(`Setting Status to: ${defaults.status}`, verbose, jsonOutput);
+          await updateItemField(
+            {
+              projectId: project.id,
+              itemId,
+              fieldId: statusField.id,
+              value: { singleSelectOptionId: option.id },
+            },
+            token,
+          );
+          fieldsSet.push('Status');
+        } else {
+          debugLog(`Warning: Status option '${defaults.status}' not found`, verbose, jsonOutput);
+        }
+      }
+    }
+
+    // Set Priority
+    if (defaults.priority) {
+      const priorityField = findField(project.fields, 'Priority');
+      if (priorityField) {
+        const option = findOption(priorityField, defaults.priority);
+        if (option) {
+          debugLog(`Setting Priority to: ${defaults.priority}`, verbose, jsonOutput);
+          await updateItemField(
+            {
+              projectId: project.id,
+              itemId,
+              fieldId: priorityField.id,
+              value: { singleSelectOptionId: option.id },
+            },
+            token,
+          );
+          fieldsSet.push('Priority');
+        } else {
+          debugLog(
+            `Warning: Priority option '${defaults.priority}' not found`,
+            verbose,
+            jsonOutput,
+          );
+        }
+      }
+    }
+
+    // Set Iteration
+    if (defaults.iteration) {
+      const iterationField = findField(project.fields, 'Iteration');
+      if (iterationField?.iterations) {
+        const iteration = findIteration(iterationField, defaults.iteration);
+        if (iteration) {
+          debugLog(`Setting Iteration to: ${defaults.iteration}`, verbose, jsonOutput);
+          await updateItemField(
+            {
+              projectId: project.id,
+              itemId,
+              fieldId: iterationField.id,
+              value: { iterationId: iteration.id },
+            },
+            token,
+          );
+          fieldsSet.push('Iteration');
+        } else {
+          debugLog(
+            `Warning: Iteration '${defaults.iteration}' not found`,
+            verbose,
+            jsonOutput,
+          );
+        }
+      }
+    }
+
+    // Set Size (number field)
+    if (defaults.size !== undefined) {
+      const sizeField = findField(project.fields, 'Size');
+      if (sizeField) {
+        debugLog(`Setting Size to: ${defaults.size}`, verbose, jsonOutput);
+        await updateItemField(
+          {
+            projectId: project.id,
+            itemId,
+            fieldId: sizeField.id,
+            value: { number: defaults.size },
+          },
+          token,
+        );
+        fieldsSet.push('Size');
+      }
+    }
+
+    // Set Estimate (number field)
+    if (defaults.estimate !== undefined) {
+      const estimateField = findField(project.fields, 'Estimate');
+      if (estimateField) {
+        debugLog(`Setting Estimate to: ${defaults.estimate}`, verbose, jsonOutput);
+        await updateItemField(
+          {
+            projectId: project.id,
+            itemId,
+            fieldId: estimateField.id,
+            value: { number: defaults.estimate },
+          },
+          token,
+        );
+        fieldsSet.push('Estimate');
+      }
+    }
+
+    // Set Start date
+    if (defaults.startDate) {
+      const startDateField = findField(project.fields, 'Start date');
+      if (startDateField) {
+        debugLog(`Setting Start date to: ${defaults.startDate}`, verbose, jsonOutput);
+        await updateItemField(
+          {
+            projectId: project.id,
+            itemId,
+            fieldId: startDateField.id,
+            value: { date: defaults.startDate },
+          },
+          token,
+        );
+        fieldsSet.push('Start date');
+      }
+    }
+
+    // Set Target date
+    if (defaults.targetDate) {
+      const targetDateField = findField(project.fields, 'Target date');
+      if (targetDateField) {
+        debugLog(`Setting Target date to: ${defaults.targetDate}`, verbose, jsonOutput);
+        await updateItemField(
+          {
+            projectId: project.id,
+            itemId,
+            fieldId: targetDateField.id,
+            value: { date: defaults.targetDate },
+          },
+          token,
+        );
+        fieldsSet.push('Target date');
+      }
+    }
+
+    const result: LinkIssueResult = {
+      success: true,
+      issueNumber,
+      projectItemId: itemId,
+      projectTitle: project.title,
+      fieldsSet,
+    };
+
+    // Output
+    if (jsonOutput) {
+      console.log(JSON.stringify(result));
+    } else {
+      console.log(colors.highlight('\n🔗 Link Issue to Project\n'));
+      console.log(`${colors.muted('Issue:')} #${issueNumber}`);
+      console.log(`${colors.muted('Repository:')} ${repo}`);
+      console.log(`${colors.muted('Project:')} ${project.title}`);
+      console.log(`${colors.muted('Item ID:')} ${itemId}`);
+      if (fieldsSet.length > 0) {
+        console.log(`${colors.muted('Fields set:')} ${fieldsSet.join(', ')}`);
+      }
+      console.log();
+      console.log(colors.success(`✓ Issue #${issueNumber} added to project`));
+    }
+
+    debugLog('Link-issue command completed successfully', verbose, jsonOutput);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    debugLog(`Error occurred: ${errorMessage}`, verbose, jsonOutput);
+
+    if (jsonOutput) {
+      const errorResult: LinkIssueResult = {
+        success: false,
+        issueNumber,
+        error: errorMessage,
+        context: {
+          repo,
+          configPath,
+        },
+      };
+      console.log(JSON.stringify(errorResult));
+    } else {
+      console.error(colors.error(`\n❌ Error: ${errorMessage}\n`));
+      if (repo || issueNumber) {
+        console.error(
+          colors.muted(
+            `Context: issue-number=${issueNumber}, repo="${repo}", config="${configPath}"`,
+          ),
+        );
+      }
+    }
+    Deno.exit(1);
+  }
+}
+
+/**
+ * Link-issue command definition
+ *
+ * Adds an issue to a GitHub Project and sets default field values.
+ *
+ * @example
+ * ```bash
+ * # Add issue to project
+ * hewg link-issue --issue-number 123 --repo owner/repo --json
+ *
+ * # With custom config path
+ * hewg link-issue -i 123 -r owner/repo -c .github/project.toml --json
+ * ```
+ */
+export const linkIssueCommand: Command = {
+  name: 'link-issue',
+  description: 'Add an issue to a GitHub Project with default field values',
+  flags: [
+    {
+      short: 'i',
+      long: 'issue-number',
+      description: 'Issue number to add to project',
+      takesValue: true,
+      required: true,
+    },
+    {
+      short: 'r',
+      long: 'repo',
+      description: 'Repository in owner/repo format',
+      takesValue: true,
+      required: true,
+    },
+    {
+      short: 'c',
+      long: 'config',
+      description: 'Path to project.toml config file',
+      takesValue: true,
+      default: '.github/project.toml',
+    },
+    {
+      long: 'json',
+      description: 'Output result as JSON',
+    },
+    {
+      short: 'V',
+      long: 'verbose',
+      description: 'Enable verbose output for debugging (writes to stderr)',
+    },
+  ],
+  action: linkIssueAction,
+};
+
+// Export internal functions for testing
+export const _internals = {
+  parseToml,
+  loadConfig,
+};

--- a/src/cli/commands/mod.ts
+++ b/src/cli/commands/mod.ts
@@ -6,5 +6,6 @@
 
 export { helloCommand } from './hello.ts';
 export { linkIssueCommand } from './link-issue.ts';
+export { prStatusCommand } from './pr-status.ts';
 export { setupActionsCommand } from './setup-actions.ts';
 export { versionCommand } from './version.ts';

--- a/src/cli/commands/mod.ts
+++ b/src/cli/commands/mod.ts
@@ -5,5 +5,6 @@
  */
 
 export { helloCommand } from './hello.ts';
+export { linkIssueCommand } from './link-issue.ts';
 export { setupActionsCommand } from './setup-actions.ts';
 export { versionCommand } from './version.ts';

--- a/src/cli/commands/pr-status.ts
+++ b/src/cli/commands/pr-status.ts
@@ -1,0 +1,566 @@
+/**
+ * PR-status command for updating issue status on pull request events
+ *
+ * This command extracts issue numbers from PR branch names and body,
+ * then updates the status of linked issues in a GitHub Project.
+ *
+ * Used by GitHub Actions to automatically update issue status when PRs are opened.
+ *
+ * @module
+ */
+
+import type { Command, CommandContext } from '../types.ts';
+import * as colors from '../colors.ts';
+import {
+  addIssueToProject,
+  findField,
+  findOption,
+  getGitHubToken,
+  getIssueNodeId,
+  getProject,
+  getProjectItems,
+  updateItemField,
+} from '../../lib/github-project.ts';
+
+/**
+ * Result of the pr-status operation
+ */
+interface PrStatusResult {
+  success: boolean;
+  prNumber: number;
+  processedIssues: number[];
+  failedIssues: number[];
+  skippedIssues: number[];
+  newStatus: string;
+  isDraft: boolean;
+  skippedDraft: boolean;
+  error?: string;
+  context?: {
+    repo: string;
+    branch: string;
+    configPath: string;
+  };
+}
+
+/**
+ * Parsed configuration for pr section
+ */
+interface PrConfig {
+  reviewStatus: string;
+  branchPattern: string;
+  ignoreDraft: boolean;
+}
+
+/**
+ * Log a debug message to stderr (to not interfere with JSON output on stdout)
+ */
+function debugLog(message: string, verbose: boolean, jsonOutput: boolean): void {
+  if (verbose && !jsonOutput) {
+    console.error(colors.muted(`[DEBUG] ${message}`));
+  }
+}
+
+/**
+ * Parse a TOML file content (simple parser for our use case)
+ */
+function parseToml(content: string): Record<string, Record<string, unknown>> {
+  const result: Record<string, Record<string, unknown>> = {};
+  let currentSection: string | null = null;
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+
+    // Skip empty lines and comments
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    // Section header
+    const sectionMatch = trimmed.match(/^\[(\w+)\]$/);
+    if (sectionMatch) {
+      currentSection = sectionMatch[1];
+      if (!result[currentSection]) result[currentSection] = {};
+      continue;
+    }
+
+    // Key-value pair
+    const kvMatch = trimmed.match(/^(\w+)\s*=\s*(.+)$/);
+    if (kvMatch && currentSection) {
+      const rawValue = kvMatch[2].trim();
+      let value: unknown = rawValue;
+
+      // Remove quotes from strings
+      if (
+        (rawValue.startsWith('"') && rawValue.endsWith('"')) ||
+        (rawValue.startsWith("'") && rawValue.endsWith("'"))
+      ) {
+        value = rawValue.slice(1, -1);
+      } // Parse arrays
+      else if (rawValue.startsWith('[') && rawValue.endsWith(']')) {
+        try {
+          value = JSON.parse(rawValue.replace(/'/g, '"'));
+        } catch {
+          value = rawValue
+            .slice(1, -1)
+            .split(',')
+            .map((s: string) => s.trim().replace(/^["']|["']$/g, ''))
+            .filter((s: string) => s);
+        }
+      } // Parse booleans
+      else if (rawValue === 'true') {
+        value = true;
+      } else if (rawValue === 'false') {
+        value = false;
+      } // Parse numbers
+      else if (/^\d+$/.test(rawValue)) {
+        value = parseInt(rawValue, 10);
+      } else if (/^\d+\.\d+$/.test(rawValue)) {
+        value = parseFloat(rawValue);
+      }
+
+      result[currentSection][kvMatch[1]] = value;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Extract issue numbers from branch name using configurable pattern
+ *
+ * @param branchName - The branch name to parse
+ * @param pattern - Regular expression pattern with capture group for issue number
+ * @returns Array of extracted issue numbers
+ *
+ * @example
+ * ```ts
+ * extractFromBranch("feature/alice/123/add-auth", "^[^/]+/[^/]+/(\\d+)/.*$")
+ * // [123]
+ * ```
+ */
+function extractFromBranch(branchName: string, pattern: string): number[] {
+  try {
+    const regex = new RegExp(pattern);
+    const match = branchName.match(regex);
+    if (match && match[1]) {
+      const num = parseInt(match[1], 10);
+      if (num > 0) return [num];
+    }
+  } catch {
+    // Invalid pattern, return empty array
+  }
+  return [];
+}
+
+/**
+ * Extract issue numbers from PR body using GitHub keywords
+ *
+ * Keywords: close[sd], fix(e[sd])?, resolve[sd]
+ *
+ * @param body - PR body text
+ * @returns Array of extracted issue numbers (deduplicated)
+ *
+ * @example
+ * ```ts
+ * extractFromBody("Fixes #123, Closes #456")
+ * // [123, 456]
+ * ```
+ */
+function extractFromBody(body: string): number[] {
+  if (!body) return [];
+
+  const regex = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+  const issues: number[] = [];
+  let match;
+
+  while ((match = regex.exec(body)) !== null) {
+    const num = parseInt(match[1], 10);
+    if (num > 0 && !issues.includes(num)) {
+      issues.push(num);
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * Load project configuration from TOML file
+ */
+async function loadConfig(configPath: string): Promise<{ projectUrl: string; pr: PrConfig }> {
+  const content = await Deno.readTextFile(configPath);
+  const config = parseToml(content);
+
+  if (!config.project?.url) {
+    throw new Error('project.url is required in configuration');
+  }
+
+  // Default PR config values
+  const prConfig: PrConfig = {
+    reviewStatus: 'In Review',
+    branchPattern: '^[^/]+/[^/]+/(\\d+)/.*$',
+    ignoreDraft: false,
+  };
+
+  if (config.pr) {
+    prConfig.reviewStatus = (config.pr.review_status as string) ?? prConfig.reviewStatus;
+    prConfig.branchPattern = (config.pr.branch_pattern as string) ?? prConfig.branchPattern;
+    prConfig.ignoreDraft = (config.pr.ignore_draft as boolean) ?? prConfig.ignoreDraft;
+  }
+
+  return {
+    projectUrl: config.project.url as string,
+    pr: prConfig,
+  };
+}
+
+/**
+ * Action handler for the pr-status command
+ */
+async function prStatusAction(ctx: CommandContext): Promise<void> {
+  let jsonOutput = false;
+  let verbose = false;
+  let prNumber = 0;
+  let repo = '';
+  let branch = '';
+  let configPath = '.github/project.toml';
+
+  try {
+    // Extract flags
+    prNumber = parseInt(ctx.flags['pr-number'] as string, 10);
+    repo = ctx.flags['repo'] as string;
+    branch = ctx.flags['branch'] as string;
+    const body = (ctx.flags['body'] as string) || '';
+    const isDraft = (ctx.flags['draft'] as boolean) ?? false;
+    configPath = (ctx.flags['config'] as string) || '.github/project.toml';
+    jsonOutput = (ctx.flags['json'] as boolean) ?? false;
+    verbose = (ctx.flags['verbose'] as boolean) ?? false;
+
+    debugLog('Starting pr-status command', verbose, jsonOutput);
+    debugLog(
+      `Flags: pr-number=${prNumber}, repo="${repo}", branch="${branch}", draft=${isDraft}`,
+      verbose,
+      jsonOutput,
+    );
+
+    // Validate required flags
+    if (!prNumber || isNaN(prNumber)) {
+      throw new Error('--pr-number is required and must be a valid number');
+    }
+
+    if (!repo) {
+      throw new Error('--repo is required (format: owner/repo)');
+    }
+
+    if (!branch) {
+      throw new Error('--branch is required');
+    }
+
+    const [owner, repoName] = repo.split('/');
+    if (!owner || !repoName) {
+      throw new Error('--repo must be in the format owner/repo');
+    }
+
+    // Get GitHub token
+    debugLog('Getting GitHub token...', verbose, jsonOutput);
+    const token = getGitHubToken();
+
+    // Load configuration
+    debugLog(`Loading config from: ${configPath}`, verbose, jsonOutput);
+    const { projectUrl, pr: prConfig } = await loadConfig(configPath);
+    debugLog(`Project URL: ${projectUrl}`, verbose, jsonOutput);
+    debugLog(`PR Config: ${JSON.stringify(prConfig)}`, verbose, jsonOutput);
+
+    // Check if draft PR should be skipped
+    if (isDraft && prConfig.ignoreDraft) {
+      debugLog('Skipping draft PR (ignore_draft is enabled)', verbose, jsonOutput);
+
+      const result: PrStatusResult = {
+        success: true,
+        prNumber,
+        processedIssues: [],
+        failedIssues: [],
+        skippedIssues: [],
+        newStatus: prConfig.reviewStatus,
+        isDraft: true,
+        skippedDraft: true,
+      };
+
+      if (jsonOutput) {
+        console.log(JSON.stringify(result));
+      } else {
+        console.log(colors.info('\n📋 PR Status Update\n'));
+        console.log(colors.muted('Skipped: Draft PR (ignore_draft is enabled)'));
+      }
+      return;
+    }
+
+    // Extract issue numbers
+    debugLog(`Extracting issues from branch: ${branch}`, verbose, jsonOutput);
+    const branchIssues = extractFromBranch(branch, prConfig.branchPattern);
+    debugLog(`Issues from branch: ${branchIssues.join(', ') || 'none'}`, verbose, jsonOutput);
+
+    debugLog('Extracting issues from PR body', verbose, jsonOutput);
+    const bodyIssues = extractFromBody(body);
+    debugLog(`Issues from body: ${bodyIssues.join(', ') || 'none'}`, verbose, jsonOutput);
+
+    // Combine and deduplicate
+    const allIssues = [...new Set([...branchIssues, ...bodyIssues])];
+    debugLog(`All issues to process: ${allIssues.join(', ') || 'none'}`, verbose, jsonOutput);
+
+    if (allIssues.length === 0) {
+      const result: PrStatusResult = {
+        success: true,
+        prNumber,
+        processedIssues: [],
+        failedIssues: [],
+        skippedIssues: [],
+        newStatus: prConfig.reviewStatus,
+        isDraft,
+        skippedDraft: false,
+      };
+
+      if (jsonOutput) {
+        console.log(JSON.stringify(result));
+      } else {
+        console.log(colors.info('\n📋 PR Status Update\n'));
+        console.log(colors.warn('No issue numbers found in branch name or PR body'));
+        console.log(colors.muted(`Branch: ${branch}`));
+        console.log(colors.muted(`Pattern: ${prConfig.branchPattern}`));
+      }
+      return;
+    }
+
+    // Get project info
+    debugLog('Fetching project information...', verbose, jsonOutput);
+    const project = await getProject(projectUrl, token);
+    debugLog(`Project: ${project.title} (${project.id})`, verbose, jsonOutput);
+
+    // Find Status field and option
+    const statusField = findField(project.fields, 'Status');
+    if (!statusField) {
+      throw new Error('Status field not found in project');
+    }
+
+    const statusOption = findOption(statusField, prConfig.reviewStatus);
+    if (!statusOption) {
+      const availableOptions = statusField.options?.map((o) => o.name).join(', ') || 'none';
+      throw new Error(
+        `Status option "${prConfig.reviewStatus}" not found. Available: ${availableOptions}`,
+      );
+    }
+    debugLog(
+      `Status field: ${statusField.id}, Option: ${statusOption.name} (${statusOption.id})`,
+      verbose,
+      jsonOutput,
+    );
+
+    // Get existing project items
+    debugLog('Fetching project items...', verbose, jsonOutput);
+    const existingItems = await getProjectItems(project.id, token);
+    const existingIssueMap = new Map(
+      existingItems.filter((i) => i.issueNumber).map((i) => [i.issueNumber!, i.id]),
+    );
+    debugLog(`Found ${existingItems.length} items in project`, verbose, jsonOutput);
+
+    // Process each issue
+    const processedIssues: number[] = [];
+    const failedIssues: number[] = [];
+    const skippedIssues: number[] = [];
+
+    for (const issueNumber of allIssues) {
+      try {
+        debugLog(`\nProcessing Issue #${issueNumber}...`, verbose, jsonOutput);
+
+        // Get issue node ID
+        const issueNodeId = await getIssueNodeId(owner, repoName, issueNumber, token);
+        debugLog(`Issue node ID: ${issueNodeId}`, verbose, jsonOutput);
+
+        // Check if issue is already in project
+        let itemId = existingIssueMap.get(issueNumber);
+
+        if (!itemId) {
+          // Add issue to project
+          debugLog(`Issue #${issueNumber} not in project, adding...`, verbose, jsonOutput);
+          itemId = await addIssueToProject(project.id, issueNodeId, token);
+          debugLog(`Added Issue #${issueNumber} to project, item ID: ${itemId}`, verbose, jsonOutput);
+        } else {
+          debugLog(
+            `Issue #${issueNumber} already in project, item ID: ${itemId}`,
+            verbose,
+            jsonOutput,
+          );
+        }
+
+        // Update Status
+        await updateItemField(
+          {
+            projectId: project.id,
+            itemId,
+            fieldId: statusField.id,
+            value: { singleSelectOptionId: statusOption.id },
+          },
+          token,
+        );
+        debugLog(
+          `Updated Issue #${issueNumber} status to: ${prConfig.reviewStatus}`,
+          verbose,
+          jsonOutput,
+        );
+        processedIssues.push(issueNumber);
+      } catch (issueError) {
+        const errorMsg = issueError instanceof Error ? issueError.message : String(issueError);
+        debugLog(`Error processing Issue #${issueNumber}: ${errorMsg}`, verbose, jsonOutput);
+        failedIssues.push(issueNumber);
+      }
+    }
+
+    const result: PrStatusResult = {
+      success: failedIssues.length === 0,
+      prNumber,
+      processedIssues,
+      failedIssues,
+      skippedIssues,
+      newStatus: prConfig.reviewStatus,
+      isDraft,
+      skippedDraft: false,
+    };
+
+    // Output
+    if (jsonOutput) {
+      console.log(JSON.stringify(result));
+    } else {
+      console.log(colors.highlight('\n📋 PR Status Update\n'));
+      console.log(`${colors.muted('PR:')} #${prNumber}`);
+      console.log(`${colors.muted('Repository:')} ${repo}`);
+      console.log(`${colors.muted('Branch:')} ${branch}`);
+      console.log(`${colors.muted('Project:')} ${project.title}`);
+      console.log(`${colors.muted('New Status:')} ${prConfig.reviewStatus}`);
+      console.log();
+      console.log(`${colors.muted('Processed:')} ${processedIssues.length} issues`);
+      if (processedIssues.length > 0) {
+        console.log(
+          `  ${colors.success('✓')} ${processedIssues.map((i) => `#${i}`).join(', ')}`,
+        );
+      }
+      if (failedIssues.length > 0) {
+        console.log(`${colors.muted('Failed:')} ${failedIssues.length} issues`);
+        console.log(`  ${colors.error('✗')} ${failedIssues.map((i) => `#${i}`).join(', ')}`);
+      }
+    }
+
+    debugLog('PR-status command completed', verbose, jsonOutput);
+
+    // Exit with error if any issues failed
+    if (failedIssues.length > 0 && processedIssues.length === 0) {
+      Deno.exit(1);
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    debugLog(`Error occurred: ${errorMessage}`, verbose, jsonOutput);
+
+    if (jsonOutput) {
+      const errorResult: PrStatusResult = {
+        success: false,
+        prNumber,
+        processedIssues: [],
+        failedIssues: [],
+        skippedIssues: [],
+        newStatus: '',
+        isDraft: false,
+        skippedDraft: false,
+        error: errorMessage,
+        context: {
+          repo,
+          branch,
+          configPath,
+        },
+      };
+      console.log(JSON.stringify(errorResult));
+    } else {
+      console.error(colors.error(`\n❌ Error: ${errorMessage}\n`));
+      if (repo || prNumber) {
+        console.error(
+          colors.muted(
+            `Context: pr-number=${prNumber}, repo="${repo}", branch="${branch}", config="${configPath}"`,
+          ),
+        );
+      }
+    }
+    Deno.exit(1);
+  }
+}
+
+/**
+ * PR-status command definition
+ *
+ * Updates issue status when a pull request is opened or reopened.
+ *
+ * @example
+ * ```bash
+ * # Update linked issues status
+ * hewg pr-status --pr-number 45 --repo owner/repo --branch feature/alice/123/add-auth --json
+ *
+ * # With PR body and draft flag
+ * hewg pr-status -p 45 -r owner/repo -b feature/alice/123/add-auth --body "Fixes #123" --draft --json
+ * ```
+ */
+export const prStatusCommand: Command = {
+  name: 'pr-status',
+  description: 'Update issue status when a pull request is opened or reopened',
+  flags: [
+    {
+      short: 'p',
+      long: 'pr-number',
+      description: 'Pull request number',
+      takesValue: true,
+      required: true,
+    },
+    {
+      short: 'r',
+      long: 'repo',
+      description: 'Repository in owner/repo format',
+      takesValue: true,
+      required: true,
+    },
+    {
+      short: 'b',
+      long: 'branch',
+      description: 'Source branch name (PR head branch)',
+      takesValue: true,
+      required: true,
+    },
+    {
+      long: 'body',
+      description: 'PR body text for extracting issue numbers',
+      takesValue: true,
+    },
+    {
+      short: 'd',
+      long: 'draft',
+      description: 'Whether the PR is a draft',
+    },
+    {
+      short: 'c',
+      long: 'config',
+      description: 'Path to project.toml config file',
+      takesValue: true,
+      default: '.github/project.toml',
+    },
+    {
+      long: 'json',
+      description: 'Output result as JSON',
+    },
+    {
+      short: 'V',
+      long: 'verbose',
+      description: 'Enable verbose output for debugging (writes to stderr)',
+    },
+  ],
+  action: prStatusAction,
+};
+
+// Export internal functions for testing
+export const _internals = {
+  parseToml,
+  extractFromBranch,
+  extractFromBody,
+  loadConfig,
+};

--- a/src/cli/commands/pr-status.ts
+++ b/src/cli/commands/pr-status.ts
@@ -380,7 +380,11 @@ async function prStatusAction(ctx: CommandContext): Promise<void> {
           // Add issue to project
           debugLog(`Issue #${issueNumber} not in project, adding...`, verbose, jsonOutput);
           itemId = await addIssueToProject(project.id, issueNodeId, token);
-          debugLog(`Added Issue #${issueNumber} to project, item ID: ${itemId}`, verbose, jsonOutput);
+          debugLog(
+            `Added Issue #${issueNumber} to project, item ID: ${itemId}`,
+            verbose,
+            jsonOutput,
+          );
         } else {
           debugLog(
             `Issue #${issueNumber} already in project, item ID: ${itemId}`,

--- a/src/lib/github-project.ts
+++ b/src/lib/github-project.ts
@@ -1,0 +1,523 @@
+/**
+ * GitHub Project API module
+ *
+ * Provides utilities for interacting with GitHub Projects V2 via GraphQL API.
+ * Used by link-issue and pr-status commands.
+ *
+ * @module
+ */
+
+import { parseProjectUrl, type ParsedProjectUrl } from '../types/project-config.ts';
+
+/**
+ * Project field type enumeration
+ */
+export type ProjectFieldType =
+  | 'SINGLE_SELECT'
+  | 'ITERATION'
+  | 'NUMBER'
+  | 'DATE'
+  | 'TEXT'
+  | 'ASSIGNEES'
+  | 'LABELS'
+  | 'MILESTONE'
+  | 'REPOSITORY'
+  | 'LINKED_PULL_REQUESTS'
+  | 'REVIEWERS'
+  | 'TRACKS'
+  | 'TRACKED_BY';
+
+/**
+ * Single select option for project fields
+ */
+export interface FieldOption {
+  id: string;
+  name: string;
+}
+
+/**
+ * Iteration option for project fields
+ */
+export interface IterationOption {
+  id: string;
+  title: string;
+}
+
+/**
+ * Project field information
+ */
+export interface ProjectField {
+  id: string;
+  name: string;
+  type?: ProjectFieldType;
+  options?: FieldOption[];
+  iterations?: IterationOption[];
+}
+
+/**
+ * GitHub Project information
+ */
+export interface Project {
+  id: string;
+  title: string;
+  fields: ProjectField[];
+}
+
+/**
+ * Project item (issue or PR in project)
+ */
+export interface ProjectItem {
+  id: string;
+  contentId?: string;
+  issueNumber?: number;
+}
+
+/**
+ * Parameters for updating a project field value
+ */
+export interface UpdateFieldParams {
+  projectId: string;
+  itemId: string;
+  fieldId: string;
+  value: FieldValue;
+}
+
+/**
+ * Field value types for updating project fields
+ */
+export type FieldValue =
+  | { singleSelectOptionId: string }
+  | { iterationId: string }
+  | { number: number }
+  | { date: string }
+  | { text: string };
+
+/**
+ * GraphQL error response
+ */
+interface GraphQLError {
+  message: string;
+  type?: string;
+  path?: string[];
+}
+
+/**
+ * GraphQL response wrapper
+ */
+interface GraphQLResponse<T> {
+  data?: T;
+  errors?: GraphQLError[];
+}
+
+/**
+ * Execute a GraphQL query against the GitHub API
+ *
+ * @param query - GraphQL query string
+ * @param variables - Query variables
+ * @param token - GitHub token for authentication
+ * @returns Query result
+ * @throws {Error} If the request fails or returns errors
+ */
+async function executeGraphQL<T>(
+  query: string,
+  variables: Record<string, unknown>,
+  token: string,
+): Promise<T> {
+  const response = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'hewg-cli',
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const result = (await response.json()) as GraphQLResponse<T>;
+
+  if (result.errors && result.errors.length > 0) {
+    const errorMessages = result.errors.map((e) => e.message).join(', ');
+    throw new Error(`GraphQL errors: ${errorMessages}`);
+  }
+
+  if (!result.data) {
+    throw new Error('No data returned from GraphQL query');
+  }
+
+  return result.data;
+}
+
+/**
+ * Get GitHub token from environment variable
+ *
+ * @returns GitHub token
+ * @throws {Error} If PROJECT_TOKEN is not set
+ */
+export function getGitHubToken(): string {
+  const token = Deno.env.get('PROJECT_TOKEN');
+  if (!token) {
+    throw new Error(
+      'PROJECT_TOKEN environment variable is not set. ' +
+        'Please set it with a GitHub token that has project scope.',
+    );
+  }
+  return token;
+}
+
+/**
+ * Get project information via GraphQL
+ *
+ * @param projectUrl - GitHub Project URL
+ * @param token - GitHub token
+ * @returns Project information with fields
+ */
+export async function getProject(projectUrl: string, token: string): Promise<Project> {
+  const projectInfo = parseProjectUrl(projectUrl);
+
+  const query = projectInfo.isOrg
+    ? `
+      query($owner: String!, $number: Int!) {
+        organization(login: $owner) {
+          projectV2(number: $number) {
+            id
+            title
+            fields(first: 50) {
+              nodes {
+                ... on ProjectV2Field {
+                  id
+                  name
+                }
+                ... on ProjectV2SingleSelectField {
+                  id
+                  name
+                  options {
+                    id
+                    name
+                  }
+                }
+                ... on ProjectV2IterationField {
+                  id
+                  name
+                  configuration {
+                    iterations {
+                      id
+                      title
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+    : `
+      query($owner: String!, $number: Int!) {
+        user(login: $owner) {
+          projectV2(number: $number) {
+            id
+            title
+            fields(first: 50) {
+              nodes {
+                ... on ProjectV2Field {
+                  id
+                  name
+                }
+                ... on ProjectV2SingleSelectField {
+                  id
+                  name
+                  options {
+                    id
+                    name
+                  }
+                }
+                ... on ProjectV2IterationField {
+                  id
+                  name
+                  configuration {
+                    iterations {
+                      id
+                      title
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+  interface ProjectQueryResult {
+    organization?: {
+      projectV2: {
+        id: string;
+        title: string;
+        fields: {
+          nodes: Array<{
+            id: string;
+            name: string;
+            options?: Array<{ id: string; name: string }>;
+            configuration?: {
+              iterations: Array<{ id: string; title: string }>;
+            };
+          }>;
+        };
+      };
+    };
+    user?: {
+      projectV2: {
+        id: string;
+        title: string;
+        fields: {
+          nodes: Array<{
+            id: string;
+            name: string;
+            options?: Array<{ id: string; name: string }>;
+            configuration?: {
+              iterations: Array<{ id: string; title: string }>;
+            };
+          }>;
+        };
+      };
+    };
+  }
+
+  const result = await executeGraphQL<ProjectQueryResult>(
+    query,
+    { owner: projectInfo.owner, number: projectInfo.number },
+    token,
+  );
+
+  const projectData = projectInfo.isOrg ? result.organization?.projectV2 : result.user?.projectV2;
+
+  if (!projectData) {
+    throw new Error(`Project not found: ${projectUrl}`);
+  }
+
+  // Transform fields to our format
+  const fields: ProjectField[] = projectData.fields.nodes
+    .filter((f) => f.id && f.name)
+    .map((f) => ({
+      id: f.id,
+      name: f.name,
+      options: f.options,
+      iterations: f.configuration?.iterations,
+    }));
+
+  return {
+    id: projectData.id,
+    title: projectData.title,
+    fields,
+  };
+}
+
+/**
+ * Get issue node ID from issue number
+ *
+ * @param owner - Repository owner
+ * @param repo - Repository name
+ * @param issueNumber - Issue number
+ * @param token - GitHub token
+ * @returns Issue node ID
+ */
+export async function getIssueNodeId(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  token: string,
+): Promise<string> {
+  const query = `
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $number) {
+          id
+        }
+      }
+    }
+  `;
+
+  interface IssueQueryResult {
+    repository: {
+      issue: {
+        id: string;
+      } | null;
+    };
+  }
+
+  const result = await executeGraphQL<IssueQueryResult>(
+    query,
+    { owner, repo, number: issueNumber },
+    token,
+  );
+
+  if (!result.repository.issue) {
+    throw new Error(`Issue #${issueNumber} not found in ${owner}/${repo}`);
+  }
+
+  return result.repository.issue.id;
+}
+
+/**
+ * Add an issue to a project
+ *
+ * @param projectId - Project ID
+ * @param issueNodeId - Issue node ID
+ * @param token - GitHub token
+ * @returns Created project item ID
+ */
+export async function addIssueToProject(
+  projectId: string,
+  issueNodeId: string,
+  token: string,
+): Promise<string> {
+  const mutation = `
+    mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+        item {
+          id
+        }
+      }
+    }
+  `;
+
+  interface AddItemResult {
+    addProjectV2ItemById: {
+      item: {
+        id: string;
+      };
+    };
+  }
+
+  const result = await executeGraphQL<AddItemResult>(
+    mutation,
+    { projectId, contentId: issueNodeId },
+    token,
+  );
+
+  return result.addProjectV2ItemById.item.id;
+}
+
+/**
+ * Update a project item field value
+ *
+ * @param params - Update parameters
+ * @param token - GitHub token
+ */
+export async function updateItemField(params: UpdateFieldParams, token: string): Promise<void> {
+  const mutation = `
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: ProjectV2FieldValue!) {
+      updateProjectV2ItemFieldValue(
+        input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: $value}
+      ) {
+        projectV2Item {
+          id
+        }
+      }
+    }
+  `;
+
+  await executeGraphQL(
+    mutation,
+    {
+      projectId: params.projectId,
+      itemId: params.itemId,
+      fieldId: params.fieldId,
+      value: params.value,
+    },
+    token,
+  );
+}
+
+/**
+ * Get all project items (issues) from a project
+ *
+ * @param projectId - Project ID
+ * @param token - GitHub token
+ * @returns List of project items with issue numbers
+ */
+export async function getProjectItems(projectId: string, token: string): Promise<ProjectItem[]> {
+  const query = `
+    query($projectId: ID!) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          items(first: 100) {
+            nodes {
+              id
+              content {
+                ... on Issue {
+                  id
+                  number
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  interface ItemsQueryResult {
+    node: {
+      items: {
+        nodes: Array<{
+          id: string;
+          content: {
+            id?: string;
+            number?: number;
+          } | null;
+        }>;
+      };
+    };
+  }
+
+  const result = await executeGraphQL<ItemsQueryResult>(query, { projectId }, token);
+
+  return result.node.items.nodes
+    .filter((item) => item.content?.number !== undefined)
+    .map((item) => ({
+      id: item.id,
+      contentId: item.content?.id,
+      issueNumber: item.content?.number,
+    }));
+}
+
+/**
+ * Find a field by name (case-insensitive)
+ *
+ * @param fields - List of project fields
+ * @param name - Field name to find
+ * @returns Field or undefined
+ */
+export function findField(fields: ProjectField[], name: string): ProjectField | undefined {
+  return fields.find((f) => f.name.toLowerCase() === name.toLowerCase());
+}
+
+/**
+ * Find an option by name in a single-select field (case-insensitive)
+ *
+ * @param field - Project field with options
+ * @param name - Option name to find
+ * @returns Option or undefined
+ */
+export function findOption(field: ProjectField, name: string): FieldOption | undefined {
+  return field.options?.find((o) => o.name.toLowerCase() === name.toLowerCase());
+}
+
+/**
+ * Find an iteration by title (case-insensitive)
+ *
+ * @param field - Project field with iterations
+ * @param title - Iteration title to find
+ * @returns Iteration or undefined
+ */
+export function findIteration(field: ProjectField, title: string): IterationOption | undefined {
+  return field.iterations?.find((i) => i.title.toLowerCase() === title.toLowerCase());
+}
+
+// Re-export parseProjectUrl for convenience
+export { parseProjectUrl, type ParsedProjectUrl };

--- a/src/lib/github-project.ts
+++ b/src/lib/github-project.ts
@@ -7,7 +7,7 @@
  * @module
  */
 
-import { parseProjectUrl, type ParsedProjectUrl } from '../types/project-config.ts';
+import { type ParsedProjectUrl, parseProjectUrl } from '../types/project-config.ts';
 
 /**
  * Project field type enumeration
@@ -520,4 +520,4 @@ export function findIteration(field: ProjectField, title: string): IterationOpti
 }
 
 // Re-export parseProjectUrl for convenience
-export { parseProjectUrl, type ParsedProjectUrl };
+export { type ParsedProjectUrl, parseProjectUrl };

--- a/src/lib/mod.ts
+++ b/src/lib/mod.ts
@@ -1,0 +1,30 @@
+/**
+ * Library modules for hewg CLI
+ *
+ * @module
+ */
+
+export {
+  addIssueToProject,
+  findField,
+  findIteration,
+  findOption,
+  getGitHubToken,
+  getIssueNodeId,
+  getProject,
+  getProjectItems,
+  parseProjectUrl,
+  updateItemField,
+} from './github-project.ts';
+
+export type {
+  FieldOption,
+  FieldValue,
+  IterationOption,
+  ParsedProjectUrl,
+  Project,
+  ProjectField,
+  ProjectFieldType,
+  ProjectItem,
+  UpdateFieldParams,
+} from './github-project.ts';

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@
 import { createCli } from './cli/mod.ts';
 import { autoTagCommand } from './cli/commands/auto-tag.ts';
 import { helloCommand } from './cli/commands/hello.ts';
+import { linkIssueCommand } from './cli/commands/link-issue.ts';
 import { setupActionsCommand } from './cli/commands/setup-actions.ts';
 import { versionCommand } from './cli/commands/version.ts';
 
@@ -21,6 +22,7 @@ const cli = createCli({
 // Register built-in commands
 cli.register(autoTagCommand);
 cli.register(helloCommand);
+cli.register(linkIssueCommand);
 cli.register(setupActionsCommand);
 cli.register(versionCommand);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { createCli } from './cli/mod.ts';
 import { autoTagCommand } from './cli/commands/auto-tag.ts';
 import { helloCommand } from './cli/commands/hello.ts';
 import { linkIssueCommand } from './cli/commands/link-issue.ts';
+import { prStatusCommand } from './cli/commands/pr-status.ts';
 import { setupActionsCommand } from './cli/commands/setup-actions.ts';
 import { versionCommand } from './cli/commands/version.ts';
 
@@ -23,6 +24,7 @@ const cli = createCli({
 cli.register(autoTagCommand);
 cli.register(helloCommand);
 cli.register(linkIssueCommand);
+cli.register(prStatusCommand);
 cli.register(setupActionsCommand);
 cli.register(versionCommand);
 

--- a/src/templates/issue-to-project.yml
+++ b/src/templates/issue-to-project.yml
@@ -20,321 +20,97 @@ jobs:
     name: Add Issue to Project
     runs-on: ubuntu-latest
     environment: project
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Add Issue to Project
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run link-issue command
+        id: link-issue
+        env:
+          PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          # Run hewg link-issue command with JSON output
+          # stdout = JSON result, stderr = Deno messages (displayed in workflow log)
+          set +e  # Temporarily disable exit on error
+          result=$(deno run --allow-read --allow-env --allow-net src/main.ts link-issue \
+            --issue-number "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --config ".github/project.toml" \
+            --json)
+          exit_code=$?
+          set -e  # Re-enable exit on error
+
+          echo "::group::CLI Output"
+          echo "$result"
+          echo "::endgroup::"
+
+          # Check if command succeeded
+          if [ $exit_code -ne 0 ]; then
+            echo "::error::CLI exited with code $exit_code"
+            echo "result=$result" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          # Validate JSON before parsing
+          if ! echo "$result" | jq -e . > /dev/null 2>&1; then
+            echo "::error::Invalid JSON output from CLI"
+            echo "Raw output: $result"
+            exit 1
+          fi
+
+          echo "result=$result" >> $GITHUB_OUTPUT
+
+          # Parse result safely with defaults
+          success=$(echo "$result" | jq -r '.success // "false"')
+          if [ "$success" != "true" ]; then
+            error=$(echo "$result" | jq -r '.error // "Unknown error"')
+            context=$(echo "$result" | jq -r '.context // empty')
+            echo "::error::Link-issue failed: $error"
+            if [ -n "$context" ]; then
+              echo "Context: $context"
+            fi
+            exit 1
+          fi
+
+          # Extract values for logging
+          echo "project_title=$(echo "$result" | jq -r '.projectTitle // ""')" >> $GITHUB_OUTPUT
+          echo "project_item_id=$(echo "$result" | jq -r '.projectItemId // ""')" >> $GITHUB_OUTPUT
+          echo "fields_set=$(echo "$result" | jq -r '.fieldsSet // [] | join(", ")')" >> $GITHUB_OUTPUT
+
+      - name: Log success
+        run: |
+          echo "✓ Issue #${{ github.event.issue.number }} added to project: ${{ steps.link-issue.outputs.project_title }}"
+          echo "  Item ID: ${{ steps.link-issue.outputs.project_item_id }}"
+          echo "  Fields set: ${{ steps.link-issue.outputs.fields_set }}"
+
+      - name: Handle failure
+        if: failure()
         uses: actions/github-script@v7
         env:
           PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
-            const fs = require('fs');
-
-            // Simple TOML parser for our specific use case
-            function parseToml(content) {
-              const result = { project: {}, defaults: {} };
-              let currentSection = null;
-
-              for (const line of content.split('\n')) {
-                const trimmed = line.trim();
-
-                // Skip empty lines and comments
-                if (!trimmed || trimmed.startsWith('#')) continue;
-
-                // Section header
-                const sectionMatch = trimmed.match(/^\[(\w+)\]$/);
-                if (sectionMatch) {
-                  currentSection = sectionMatch[1];
-                  if (!result[currentSection]) result[currentSection] = {};
-                  continue;
-                }
-
-                // Key-value pair
-                const kvMatch = trimmed.match(/^(\w+)\s*=\s*(.+)$/);
-                if (kvMatch && currentSection) {
-                  let value = kvMatch[2].trim();
-                  // Remove quotes from strings
-                  if ((value.startsWith('"') && value.endsWith('"')) ||
-                      (value.startsWith("'") && value.endsWith("'"))) {
-                    value = value.slice(1, -1);
-                  }
-                  // Parse numbers
-                  else if (/^\d+$/.test(value)) {
-                    value = parseInt(value, 10);
-                  }
-                  else if (/^\d+\.\d+$/.test(value)) {
-                    value = parseFloat(value);
-                  }
-                  result[currentSection][kvMatch[1]] = value;
-                }
-              }
-
-              return result;
-            }
-
-            // Parse project URL to extract owner and number
-            function parseProjectUrl(url) {
-              const userMatch = url.match(/github\.com\/users\/([^/]+)\/projects\/(\d+)/);
-              if (userMatch) {
-                return { owner: userMatch[1], number: parseInt(userMatch[2], 10), isOrg: false };
-              }
-              const orgMatch = url.match(/github\.com\/orgs\/([^/]+)\/projects\/(\d+)/);
-              if (orgMatch) {
-                return { owner: orgMatch[1], number: parseInt(orgMatch[2], 10), isOrg: true };
-              }
-              throw new Error(`Invalid project URL: ${url}`);
-            }
-
-            // Comment on issue with error message
-            async function commentError(message, runUrl) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: `:warning: **Failed to add this issue to the project**\n\n**Error**: ${message}\n\n**Troubleshooting**:\n- Ensure \`PROJECT_TOKEN\` secret is configured with \`project\` scope\n- Verify the project URL in \`.github/project.toml\`\n- Check that the token owner has access to the project\n\n[View workflow run](${runUrl})`
-              });
-            }
-
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
-            try {
-              // Read and parse config
-              const configPath = '.github/project.toml';
-              if (!fs.existsSync(configPath)) {
-                throw new Error(`Configuration file not found: ${configPath}`);
-              }
-
-              const configContent = fs.readFileSync(configPath, 'utf8');
-              const config = parseToml(configContent);
-
-              if (!config.project?.url) {
-                throw new Error('project.url is required in configuration');
-              }
-
-              const projectInfo = parseProjectUrl(config.project.url);
-              console.log(`Adding issue to project: ${projectInfo.owner}/${projectInfo.number}`);
-
-              // Get project ID
-              const projectQuery = projectInfo.isOrg ? `
-                query($owner: String!, $number: Int!) {
-                  organization(login: $owner) {
-                    projectV2(number: $number) {
-                      id
-                      title
-                      fields(first: 20) {
-                        nodes {
-                          ... on ProjectV2Field {
-                            id
-                            name
-                          }
-                          ... on ProjectV2SingleSelectField {
-                            id
-                            name
-                            options {
-                              id
-                              name
-                            }
-                          }
-                          ... on ProjectV2IterationField {
-                            id
-                            name
-                            configuration {
-                              iterations {
-                                id
-                                title
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              ` : `
-                query($owner: String!, $number: Int!) {
-                  user(login: $owner) {
-                    projectV2(number: $number) {
-                      id
-                      title
-                      fields(first: 20) {
-                        nodes {
-                          ... on ProjectV2Field {
-                            id
-                            name
-                          }
-                          ... on ProjectV2SingleSelectField {
-                            id
-                            name
-                            options {
-                              id
-                              name
-                            }
-                          }
-                          ... on ProjectV2IterationField {
-                            id
-                            name
-                            configuration {
-                              iterations {
-                                id
-                                title
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              `;
-
-              const projectResult = await github.graphql(projectQuery, {
-                owner: projectInfo.owner,
-                number: projectInfo.number
-              });
-
-              const project = projectInfo.isOrg
-                ? projectResult.organization?.projectV2
-                : projectResult.user?.projectV2;
-
-              if (!project) {
-                throw new Error(`Project not found: ${config.project.url}`);
-              }
-
-              console.log(`Found project: ${project.title} (${project.id})`);
-
-              // Add issue to project
-              const addResult = await github.graphql(`
-                mutation($projectId: ID!, $contentId: ID!) {
-                  addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
-                    item {
-                      id
-                    }
-                  }
-                }
-              `, {
-                projectId: project.id,
-                contentId: context.payload.issue.node_id
-              });
-
-              const itemId = addResult.addProjectV2ItemById.item.id;
-              console.log(`Added issue to project, item ID: ${itemId}`);
-
-              // Set default field values if configured
-              const defaults = config.defaults || {};
-              const fields = project.fields.nodes;
-
-              // Helper to find field and option
-              function findField(name) {
-                return fields.find(f => f.name?.toLowerCase() === name.toLowerCase());
-              }
-
-              function findOption(field, value) {
-                return field.options?.find(o => o.name?.toLowerCase() === value.toLowerCase());
-              }
-
-              // Set Status
-              if (defaults.status) {
-                const statusField = findField('Status');
-                if (statusField) {
-                  const option = findOption(statusField, defaults.status);
-                  if (option) {
-                    await github.graphql(`
-                      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
-                        updateProjectV2ItemFieldValue(
-                          input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: {singleSelectOptionId: $value}}
-                        ) { projectV2Item { id } }
-                      }
-                    `, { projectId: project.id, itemId, fieldId: statusField.id, value: option.id });
-                    console.log(`Set Status to: ${defaults.status}`);
-                  } else {
-                    console.log(`Warning: Status option '${defaults.status}' not found`);
-                  }
-                }
-              }
-
-              // Set Priority
-              if (defaults.priority) {
-                const priorityField = findField('Priority');
-                if (priorityField) {
-                  const option = findOption(priorityField, defaults.priority);
-                  if (option) {
-                    await github.graphql(`
-                      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
-                        updateProjectV2ItemFieldValue(
-                          input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: {singleSelectOptionId: $value}}
-                        ) { projectV2Item { id } }
-                      }
-                    `, { projectId: project.id, itemId, fieldId: priorityField.id, value: option.id });
-                    console.log(`Set Priority to: ${defaults.priority}`);
-                  } else {
-                    console.log(`Warning: Priority option '${defaults.priority}' not found`);
-                  }
-                }
-              }
-
-              // Set Iteration
-              if (defaults.iteration) {
-                const iterationField = findField('Iteration');
-                if (iterationField?.configuration?.iterations) {
-                  const iteration = iterationField.configuration.iterations.find(
-                    i => i.title?.toLowerCase() === defaults.iteration.toLowerCase()
-                  );
-                  if (iteration) {
-                    await github.graphql(`
-                      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
-                        updateProjectV2ItemFieldValue(
-                          input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: {iterationId: $value}}
-                        ) { projectV2Item { id } }
-                      }
-                    `, { projectId: project.id, itemId, fieldId: iterationField.id, value: iteration.id });
-                    console.log(`Set Iteration to: ${defaults.iteration}`);
-                  } else {
-                    console.log(`Warning: Iteration '${defaults.iteration}' not found`);
-                  }
-                }
-              }
-
-              // Set numeric fields (Size, Estimate)
-              for (const [key, fieldName] of [['size', 'Size'], ['estimate', 'Estimate']]) {
-                if (defaults[key] !== undefined) {
-                  const field = findField(fieldName);
-                  if (field) {
-                    await github.graphql(`
-                      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: Float!) {
-                        updateProjectV2ItemFieldValue(
-                          input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: {number: $value}}
-                        ) { projectV2Item { id } }
-                      }
-                    `, { projectId: project.id, itemId, fieldId: field.id, value: defaults[key] });
-                    console.log(`Set ${fieldName} to: ${defaults[key]}`);
-                  }
-                }
-              }
-
-              // Set date fields
-              for (const [key, fieldName] of [['start_date', 'Start date'], ['target_date', 'Target date']]) {
-                if (defaults[key]) {
-                  const field = findField(fieldName);
-                  if (field) {
-                    await github.graphql(`
-                      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: Date!) {
-                        updateProjectV2ItemFieldValue(
-                          input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: {date: $value}}
-                        ) { projectV2Item { id } }
-                      }
-                    `, { projectId: project.id, itemId, fieldId: field.id, value: defaults[key] });
-                    console.log(`Set ${fieldName} to: ${defaults[key]}`);
-                  }
-                }
-              }
-
-              console.log('Successfully added issue to project with default values');
-
-            } catch (error) {
-              console.error(`Error: ${error.message}`);
-              await commentError(error.message, runUrl);
-              core.setFailed(error.message);
-            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                ':warning: **Failed to add this issue to the project**',
+                '',
+                '**Troubleshooting**:',
+                '- Ensure `PROJECT_TOKEN` secret is configured with `project` scope',
+                '- Verify the project URL in `.github/project.toml`',
+                '- Check that the token owner has access to the project',
+                '',
+                `[View workflow run](${runUrl})`
+              ].join('\n')
+            });

--- a/src/templates/pr-status-update.yml
+++ b/src/templates/pr-status-update.yml
@@ -24,391 +24,174 @@ jobs:
     name: Update Issue Status
     runs-on: ubuntu-latest
     environment: project
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Update Issue Status
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run pr-status command
+        id: pr-status
+        env:
+          PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          # Run hewg pr-status command with JSON output
+          # stdout = JSON result, stderr = Deno messages (displayed in workflow log)
+          set +e  # Temporarily disable exit on error
+
+          # Build command arguments
+          draft_flag=""
+          if [ "${{ github.event.pull_request.draft }}" = "true" ]; then
+            draft_flag="--draft"
+          fi
+
+          # Use heredoc for body to handle special characters
+          body_content='${{ github.event.pull_request.body }}'
+
+          result=$(deno run --allow-read --allow-env --allow-net src/main.ts pr-status \
+            --pr-number "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --branch "${{ github.head_ref }}" \
+            --body "$body_content" \
+            $draft_flag \
+            --config ".github/project.toml" \
+            --json)
+          exit_code=$?
+          set -e  # Re-enable exit on error
+
+          echo "::group::CLI Output"
+          echo "$result"
+          echo "::endgroup::"
+
+          # Check if command succeeded
+          if [ $exit_code -ne 0 ]; then
+            echo "::error::CLI exited with code $exit_code"
+            echo "result=$result" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          # Validate JSON before parsing
+          if ! echo "$result" | jq -e . > /dev/null 2>&1; then
+            echo "::error::Invalid JSON output from CLI"
+            echo "Raw output: $result"
+            exit 1
+          fi
+
+          echo "result=$result" >> $GITHUB_OUTPUT
+
+          # Parse result safely with defaults
+          success=$(echo "$result" | jq -r '.success // "false"')
+          skipped_draft=$(echo "$result" | jq -r '.skippedDraft // "false"')
+
+          # Handle skipped draft case
+          if [ "$skipped_draft" = "true" ]; then
+            echo "::notice::Skipped draft PR (ignore_draft is enabled)"
+            exit 0
+          fi
+
+          if [ "$success" != "true" ]; then
+            error=$(echo "$result" | jq -r '.error // "Unknown error"')
+            context=$(echo "$result" | jq -r '.context // empty')
+            echo "::error::PR-status failed: $error"
+            if [ -n "$context" ]; then
+              echo "Context: $context"
+            fi
+            exit 1
+          fi
+
+          # Extract values for logging/comment
+          echo "processed_issues=$(echo "$result" | jq -r '.processedIssues // [] | map("#" + tostring) | join(", ")')" >> $GITHUB_OUTPUT
+          echo "failed_issues=$(echo "$result" | jq -r '.failedIssues // [] | map("#" + tostring) | join(", ")')" >> $GITHUB_OUTPUT
+          echo "new_status=$(echo "$result" | jq -r '.newStatus // ""')" >> $GITHUB_OUTPUT
+          echo "processed_count=$(echo "$result" | jq -r '.processedIssues | length')" >> $GITHUB_OUTPUT
+          echo "failed_count=$(echo "$result" | jq -r '.failedIssues | length')" >> $GITHUB_OUTPUT
+
+      - name: Log success
+        if: steps.pr-status.outputs.processed_count != '0'
+        run: |
+          echo "✓ Updated status to '${{ steps.pr-status.outputs.new_status }}' for issues: ${{ steps.pr-status.outputs.processed_issues }}"
+          if [ -n "${{ steps.pr-status.outputs.failed_issues }}" ]; then
+            echo "✗ Failed to update: ${{ steps.pr-status.outputs.failed_issues }}"
+          fi
+
+      - name: Comment on PR (no issues found)
+        if: steps.pr-status.outputs.processed_count == '0' && steps.pr-status.outputs.failed_count == '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branchName = '${{ github.head_ref }}';
+            const prBody = `${{ github.event.pull_request.body }}`;
+            const hasBody = prBody && prBody.trim().length > 0;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                ':information_source: **No linked Issues found**',
+                '',
+                'Could not find Issue numbers in:',
+                `- Branch name: \`${branchName}\``,
+                `- PR body keywords: ${hasBody ? '(none matching)' : '(empty)'}`,
+                '',
+                '**Expected formats**:',
+                '- Branch: `label/author/{issue_number}/title`',
+                '- Keywords: `Closes #N`, `Fixes #N`, `Resolves #N`'
+              ].join('\n')
+            });
+
+      - name: Handle partial failure
+        if: steps.pr-status.outputs.failed_count != '0' && steps.pr-status.outputs.processed_count != '0'
         uses: actions/github-script@v7
         env:
           PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
-            const fs = require('fs');
-
-            // Simple TOML parser for our specific use case
-            function parseToml(content) {
-              const result = { project: {}, defaults: {}, pr: {} };
-              let currentSection = null;
-
-              for (const line of content.split('\n')) {
-                const trimmed = line.trim();
-
-                // Skip empty lines and comments
-                if (!trimmed || trimmed.startsWith('#')) continue;
-
-                // Section header
-                const sectionMatch = trimmed.match(/^\[(\w+)\]$/);
-                if (sectionMatch) {
-                  currentSection = sectionMatch[1];
-                  if (!result[currentSection]) result[currentSection] = {};
-                  continue;
-                }
-
-                // Key-value pair
-                const kvMatch = trimmed.match(/^(\w+)\s*=\s*(.+)$/);
-                if (kvMatch && currentSection) {
-                  let value = kvMatch[2].trim();
-                  // Remove quotes from strings
-                  if ((value.startsWith('"') && value.endsWith('"')) ||
-                      (value.startsWith("'") && value.endsWith("'"))) {
-                    value = value.slice(1, -1);
-                  }
-                  // Parse booleans
-                  else if (value === 'true') {
-                    value = true;
-                  }
-                  else if (value === 'false') {
-                    value = false;
-                  }
-                  // Parse numbers
-                  else if (/^\d+$/.test(value)) {
-                    value = parseInt(value, 10);
-                  }
-                  else if (/^\d+\.\d+$/.test(value)) {
-                    value = parseFloat(value);
-                  }
-                  result[currentSection][kvMatch[1]] = value;
-                }
-              }
-
-              return result;
-            }
-
-            // Parse project URL to extract owner and number
-            function parseProjectUrl(url) {
-              const userMatch = url.match(/github\.com\/users\/([^/]+)\/projects\/(\d+)/);
-              if (userMatch) {
-                return { owner: userMatch[1], number: parseInt(userMatch[2], 10), isOrg: false };
-              }
-              const orgMatch = url.match(/github\.com\/orgs\/([^/]+)\/projects\/(\d+)/);
-              if (orgMatch) {
-                return { owner: orgMatch[1], number: parseInt(orgMatch[2], 10), isOrg: true };
-              }
-              throw new Error(`Invalid project URL: ${url}`);
-            }
-
-            // Extract Issue numbers from branch name
-            function extractFromBranch(branchName, pattern) {
-              try {
-                const regex = new RegExp(pattern);
-                const match = branchName.match(regex);
-                if (match && match[1]) {
-                  const num = parseInt(match[1], 10);
-                  if (num > 0) return [num];
-                }
-              } catch (e) {
-                console.log(`Warning: Invalid branch pattern: ${pattern}`);
-              }
-              return [];
-            }
-
-            // Extract Issue numbers from PR body using keywords
-            function extractFromBody(body) {
-              if (!body) return [];
-              const regex = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
-              const issues = [];
-              let match;
-              while ((match = regex.exec(body)) !== null) {
-                const num = parseInt(match[1], 10);
-                if (num > 0 && !issues.includes(num)) {
-                  issues.push(num);
-                }
-              }
-              return issues;
-            }
-
-            // Comment on PR with message
-            async function commentOnPR(message) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body: message
-              });
-            }
-
-            // Comment on PR with error message
-            async function commentError(message, runUrl, processedIssues = [], failedIssues = []) {
-              let body = `:warning: **Failed to update Issue status**\n\n**Error**: ${message}\n\n`;
-
-              if (processedIssues.length > 0) {
-                body += `**Issues processed**: ${processedIssues.map(i => `#${i}`).join(', ')}\n`;
-              }
-              if (failedIssues.length > 0) {
-                body += `**Issues failed**: ${failedIssues.map(i => `#${i}`).join(', ')}\n`;
-              }
-
-              body += `\n**Troubleshooting**:\n- Ensure \`PROJECT_TOKEN\` secret is configured with \`project\` scope\n- Verify the project URL in \`.github/project.toml\`\n- Check that the status option "${config?.pr?.review_status || 'In Review'}" exists in your project\n\n[View workflow run](${runUrl})`;
-
-              await commentOnPR(body);
-            }
-
-            // Comment warning when no Issues found
-            async function commentNoIssuesFound(branchName, prBody) {
-              const body = `:information_source: **No linked Issues found**\n\nCould not find Issue numbers in:\n- Branch name: \`${branchName}\`\n- PR body keywords: ${prBody ? '(none matching)' : '(empty)'}\n\n**Expected formats**:\n- Branch: \`label/author/{issue_number}/title\`\n- Keywords: \`Closes #N\`, \`Fixes #N\`, \`Resolves #N\``;
-
-              await commentOnPR(body);
-            }
-
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            let config;
+            const processed = '${{ steps.pr-status.outputs.processed_issues }}';
+            const failed = '${{ steps.pr-status.outputs.failed_issues }}';
 
-            try {
-              // Read and parse config
-              const configPath = '.github/project.toml';
-              if (!fs.existsSync(configPath)) {
-                throw new Error(`Configuration file not found: ${configPath}`);
-              }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                ':warning: **Partial success updating Issue status**',
+                '',
+                `**Successfully updated**: ${processed}`,
+                `**Failed**: ${failed}`,
+                '',
+                `[View workflow run](${runUrl})`
+              ].join('\n')
+            });
 
-              const configContent = fs.readFileSync(configPath, 'utf8');
-              config = parseToml(configContent);
+      - name: Handle failure
+        if: failure()
+        uses: actions/github-script@v7
+        env:
+          PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
-              if (!config.project?.url) {
-                throw new Error('project.url is required in configuration');
-              }
-
-              // Get PR config with defaults
-              const prConfig = {
-                review_status: config.pr?.review_status || 'In Review',
-                branch_pattern: config.pr?.branch_pattern || '^[^/]+/[^/]+/(\\d+)/.*$',
-                ignore_draft: config.pr?.ignore_draft || false
-              };
-
-              const pr = context.payload.pull_request;
-
-              // Check if Draft PR should be ignored
-              if (prConfig.ignore_draft && pr.draft) {
-                console.log('Skipping Draft PR (ignore_draft is enabled)');
-                return;
-              }
-
-              // Extract Issue numbers
-              const branchName = pr.head.ref;
-              const prBody = pr.body || '';
-
-              const branchIssues = extractFromBranch(branchName, prConfig.branch_pattern);
-              const bodyIssues = extractFromBody(prBody);
-
-              // Combine and deduplicate
-              const allIssues = [...new Set([...branchIssues, ...bodyIssues])];
-
-              console.log(`Branch: ${branchName}`);
-              console.log(`Issues from branch: ${branchIssues.join(', ') || 'none'}`);
-              console.log(`Issues from body: ${bodyIssues.join(', ') || 'none'}`);
-              console.log(`All Issues to process: ${allIssues.join(', ') || 'none'}`);
-
-              if (allIssues.length === 0) {
-                await commentNoIssuesFound(branchName, prBody);
-                console.log('No Issue numbers found, commented on PR');
-                return;
-              }
-
-              // Parse project URL
-              const projectInfo = parseProjectUrl(config.project.url);
-              console.log(`Project: ${projectInfo.owner}/${projectInfo.number}`);
-
-              // Get project ID and fields
-              const projectQuery = projectInfo.isOrg ? `
-                query($owner: String!, $number: Int!) {
-                  organization(login: $owner) {
-                    projectV2(number: $number) {
-                      id
-                      title
-                      fields(first: 20) {
-                        nodes {
-                          ... on ProjectV2Field {
-                            id
-                            name
-                          }
-                          ... on ProjectV2SingleSelectField {
-                            id
-                            name
-                            options {
-                              id
-                              name
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              ` : `
-                query($owner: String!, $number: Int!) {
-                  user(login: $owner) {
-                    projectV2(number: $number) {
-                      id
-                      title
-                      fields(first: 20) {
-                        nodes {
-                          ... on ProjectV2Field {
-                            id
-                            name
-                          }
-                          ... on ProjectV2SingleSelectField {
-                            id
-                            name
-                            options {
-                              id
-                              name
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              `;
-
-              const projectResult = await github.graphql(projectQuery, {
-                owner: projectInfo.owner,
-                number: projectInfo.number
-              });
-
-              const project = projectInfo.isOrg
-                ? projectResult.organization?.projectV2
-                : projectResult.user?.projectV2;
-
-              if (!project) {
-                throw new Error(`Project not found: ${config.project.url}`);
-              }
-
-              console.log(`Found project: ${project.title} (${project.id})`);
-
-              // Find Status field and option
-              const statusField = project.fields.nodes.find(f => f.name?.toLowerCase() === 'status');
-              if (!statusField) {
-                throw new Error('Status field not found in project');
-              }
-
-              const statusOption = statusField.options?.find(
-                o => o.name?.toLowerCase() === prConfig.review_status.toLowerCase()
-              );
-              if (!statusOption) {
-                throw new Error(`Status option "${prConfig.review_status}" not found. Available: ${statusField.options?.map(o => o.name).join(', ')}`);
-              }
-
-              console.log(`Status field: ${statusField.id}, Option: ${statusOption.name} (${statusOption.id})`);
-
-              // Process each Issue
-              const processedIssues = [];
-              const failedIssues = [];
-
-              for (const issueNumber of allIssues) {
-                try {
-                  console.log(`\nProcessing Issue #${issueNumber}...`);
-
-                  // Get Issue node ID
-                  const issueResult = await github.rest.issues.get({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: issueNumber
-                  });
-
-                  const issueNodeId = issueResult.data.node_id;
-                  console.log(`Issue node ID: ${issueNodeId}`);
-
-                  // Check if Issue is already in project
-                  const itemsQuery = `
-                    query($projectId: ID!) {
-                      node(id: $projectId) {
-                        ... on ProjectV2 {
-                          items(first: 100) {
-                            nodes {
-                              id
-                              content {
-                                ... on Issue {
-                                  id
-                                  number
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  `;
-
-                  const itemsResult = await github.graphql(itemsQuery, { projectId: project.id });
-                  const items = itemsResult.node?.items?.nodes || [];
-                  let projectItem = items.find(item => item.content?.number === issueNumber);
-
-                  if (!projectItem) {
-                    // Add Issue to project
-                    console.log(`Issue #${issueNumber} not in project, adding...`);
-
-                    const addResult = await github.graphql(`
-                      mutation($projectId: ID!, $contentId: ID!) {
-                        addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
-                          item {
-                            id
-                          }
-                        }
-                      }
-                    `, {
-                      projectId: project.id,
-                      contentId: issueNodeId
-                    });
-
-                    projectItem = { id: addResult.addProjectV2ItemById.item.id };
-                    console.log(`Added Issue #${issueNumber} to project, item ID: ${projectItem.id}`);
-                  } else {
-                    console.log(`Issue #${issueNumber} already in project, item ID: ${projectItem.id}`);
-                  }
-
-                  // Update Status
-                  await github.graphql(`
-                    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
-                      updateProjectV2ItemFieldValue(
-                        input: {projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: {singleSelectOptionId: $value}}
-                      ) { projectV2Item { id } }
-                    }
-                  `, {
-                    projectId: project.id,
-                    itemId: projectItem.id,
-                    fieldId: statusField.id,
-                    value: statusOption.id
-                  });
-
-                  console.log(`Updated Issue #${issueNumber} status to: ${prConfig.review_status}`);
-                  processedIssues.push(issueNumber);
-
-                } catch (issueError) {
-                  console.error(`Error processing Issue #${issueNumber}: ${issueError.message}`);
-                  failedIssues.push(issueNumber);
-                }
-              }
-
-              // Summary
-              console.log(`\n=== Summary ===`);
-              console.log(`Processed: ${processedIssues.length} issues`);
-              console.log(`Failed: ${failedIssues.length} issues`);
-
-              if (failedIssues.length > 0 && processedIssues.length > 0) {
-                // Partial success
-                await commentOnPR(`:warning: **Partial success updating Issue status**\n\n**Successfully updated**: ${processedIssues.map(i => `#${i}`).join(', ')}\n**Failed**: ${failedIssues.map(i => `#${i}`).join(', ')}\n\n[View workflow run](${runUrl})`);
-              } else if (failedIssues.length > 0) {
-                // All failed
-                await commentError('Failed to process all Issues', runUrl, [], failedIssues);
-                core.setFailed('Failed to process all Issues');
-              } else {
-                console.log('All Issues processed successfully');
-              }
-
-            } catch (error) {
-              console.error(`Error: ${error.message}`);
-              await commentError(error.message, runUrl);
-              core.setFailed(error.message);
-            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                ':warning: **Failed to update Issue status**',
+                '',
+                '**Troubleshooting**:',
+                '- Ensure `PROJECT_TOKEN` secret is configured with `project` scope',
+                '- Verify the project URL in `.github/project.toml`',
+                '- Check that the status option exists in your project',
+                '',
+                `[View workflow run](${runUrl})`
+              ].join('\n')
+            });

--- a/tests/link-issue_test.ts
+++ b/tests/link-issue_test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for link-issue command
+ */
+
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+import { _internals } from '../src/cli/commands/link-issue.ts';
+
+const { parseToml } = _internals;
+
+describe('parseToml', () => {
+  it('should parse project section with URL', () => {
+    const content = `
+[project]
+url = "https://github.com/users/testuser/projects/1"
+    `;
+    const result = parseToml(content);
+    assertEquals(result.project.url, 'https://github.com/users/testuser/projects/1');
+  });
+
+  it('should parse defaults section', () => {
+    const content = `
+[project]
+url = "https://github.com/users/testuser/projects/1"
+
+[defaults]
+status = "Todo"
+priority = "P1"
+size = 3
+    `;
+    const result = parseToml(content);
+    assertEquals(result.defaults.status, 'Todo');
+    assertEquals(result.defaults.priority, 'P1');
+    assertEquals(result.defaults.size, 3);
+  });
+
+  it('should parse date values', () => {
+    const content = `
+[defaults]
+start_date = "2026-01-01"
+target_date = "2026-01-15"
+    `;
+    const result = parseToml(content);
+    assertEquals(result.defaults.start_date, '2026-01-01');
+    assertEquals(result.defaults.target_date, '2026-01-15');
+  });
+
+  it('should skip comments', () => {
+    const content = `
+# This is a comment
+[project]
+# Another comment
+url = "https://github.com/users/testuser/projects/1"
+    `;
+    const result = parseToml(content);
+    assertEquals(result.project.url, 'https://github.com/users/testuser/projects/1');
+  });
+});

--- a/tests/pr-status_test.ts
+++ b/tests/pr-status_test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for pr-status command
+ */
+
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+import { _internals } from '../src/cli/commands/pr-status.ts';
+
+const { extractFromBranch, extractFromBody } = _internals;
+
+describe('extractFromBranch', () => {
+  const defaultPattern = '^[^/]+/[^/]+/(\\d+)/.*$';
+
+  it('should extract issue number from standard branch name', () => {
+    const result = extractFromBranch('feature/alice/123/add-auth', defaultPattern);
+    assertEquals(result, [123]);
+  });
+
+  it('should extract issue number from branch with # prefix', () => {
+    const result = extractFromBranch('feature/alice/#123/add-auth', '^[^/]+/[^/]+/#(\\d+)/.*$');
+    assertEquals(result, [123]);
+  });
+
+  it('should return empty array for non-matching branch', () => {
+    const result = extractFromBranch('main', defaultPattern);
+    assertEquals(result, []);
+  });
+
+  it('should return empty array for develop branch', () => {
+    const result = extractFromBranch('develop', defaultPattern);
+    assertEquals(result, []);
+  });
+
+  it('should handle invalid regex pattern', () => {
+    const result = extractFromBranch('feature/alice/123/add-auth', '[invalid');
+    assertEquals(result, []);
+  });
+
+  it('should extract from bugfix branch', () => {
+    const result = extractFromBranch('bugfix/bob/456/fix-memory-leak', defaultPattern);
+    assertEquals(result, [456]);
+  });
+});
+
+describe('extractFromBody', () => {
+  it('should extract issue number from Closes keyword', () => {
+    const result = extractFromBody('Closes #123');
+    assertEquals(result, [123]);
+  });
+
+  it('should extract issue number from Fixes keyword', () => {
+    const result = extractFromBody('Fixes #456');
+    assertEquals(result, [456]);
+  });
+
+  it('should extract issue number from Resolves keyword', () => {
+    const result = extractFromBody('Resolves #789');
+    assertEquals(result, [789]);
+  });
+
+  it('should extract multiple issue numbers', () => {
+    const result = extractFromBody('Fixes #123, Closes #456');
+    assertEquals(result, [123, 456]);
+  });
+
+  it('should deduplicate issue numbers', () => {
+    const result = extractFromBody('Fixes #123, Also fixes #123');
+    assertEquals(result, [123]);
+  });
+
+  it('should handle case-insensitive keywords', () => {
+    const result = extractFromBody('CLOSES #123, fixes #456, ReSOLVES #789');
+    assertEquals(result, [123, 456, 789]);
+  });
+
+  it('should return empty array for empty body', () => {
+    const result = extractFromBody('');
+    assertEquals(result, []);
+  });
+
+  it('should return empty array for body without keywords', () => {
+    const result = extractFromBody('This is a description without issue references');
+    assertEquals(result, []);
+  });
+
+  it('should handle past tense keywords', () => {
+    const result = extractFromBody('Closed #123, Fixed #456, Resolved #789');
+    assertEquals(result, [123, 456, 789]);
+  });
+});


### PR DESCRIPTION
## Summary

- Refactor `issue-to-project.yml` and `pr-status-update.yml` to use hewg CLI commands instead of inline JavaScript
- Add `link-issue` command for adding issues to GitHub Projects with default field values
- Add `pr-status` command for updating issue status when PRs are opened/reopened

Closes #13

## 変更内容 (Changes)

### 新規追加 (New Files)
- `src/lib/github-project.ts` - GitHub Project GraphQL API モジュール
- `src/cli/commands/link-issue.ts` - Issue をプロジェクトにリンクするコマンド
- `src/cli/commands/pr-status.ts` - PR オープン時に Issue ステータスを更新するコマンド
- `tests/link-issue_test.ts`, `tests/pr-status_test.ts` - ユニットテスト
- `docs/design/issue-#13-*.md`, `docs/workflow/issue-#13-*.md` - 設計・ワークフロードキュメント

### リファクタリング (Refactored)
- `.github/workflows/issue-to-project.yml` (341行 → 117行, -66%)
- `.github/workflows/pr-status-update.yml` (415行 → 198行, -52%)

## Test plan
- [x] `deno fmt --check` - フォーマットチェック通過
- [x] `deno lint` - リントチェック通過
- [x] `deno check` - 型チェック通過
- [x] `deno test` - 26テスト全て通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
