### PR TITLE
fix: add project field initial value setting and improve error handling

### DIFF
--- a/.github/workflows/issue-to-project.yml
+++ b/.github/workflows/issue-to-project.yml
@@ -50,38 +50,56 @@ jobs:
           echo "$result"
           echo "::endgroup::"
 
-          # Check if command succeeded
-          if [ $exit_code -ne 0 ]; then
-            echo "::error::CLI exited with code $exit_code"
-            echo "result=$result" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-
           # Validate JSON before parsing
           if ! echo "$result" | jq -e . > /dev/null 2>&1; then
             echo "::error::Invalid JSON output from CLI"
             echo "Raw output: $result"
+            echo "result={}" >> $GITHUB_OUTPUT
+            echo "has_warnings=false" >> $GITHUB_OUTPUT
             exit 1
           fi
 
           echo "result=$result" >> $GITHUB_OUTPUT
 
-          # Parse result safely with defaults
-          success=$(echo "$result" | jq -r '.success // "false"')
-          if [ "$success" != "true" ]; then
-            error=$(echo "$result" | jq -r '.error // "Unknown error"')
-            context=$(echo "$result" | jq -r '.context // empty')
-            echo "::error::Link-issue failed: $error"
-            if [ -n "$context" ]; then
-              echo "Context: $context"
-            fi
-            exit 1
-          fi
-
           # Extract values for logging
           echo "project_title=$(echo "$result" | jq -r '.projectTitle // ""')" >> $GITHUB_OUTPUT
           echo "project_item_id=$(echo "$result" | jq -r '.projectItemId // ""')" >> $GITHUB_OUTPUT
           echo "fields_set=$(echo "$result" | jq -r '.fieldsSet // [] | join(", ")')" >> $GITHUB_OUTPUT
+
+          # Check for field warnings (partial success)
+          warnings=$(echo "$result" | jq -r '.fieldWarnings // []')
+          warning_count=$(echo "$result" | jq -r '.fieldWarnings // [] | length')
+          if [ "$warning_count" -gt 0 ]; then
+            echo "has_warnings=true" >> $GITHUB_OUTPUT
+            echo "warning_count=$warning_count" >> $GITHUB_OUTPUT
+            # Format warnings for display
+            warning_details=$(echo "$result" | jq -r '.fieldWarnings[] | "- \(.field): \(.reason)"')
+            echo "warning_details<<EOF" >> $GITHUB_OUTPUT
+            echo "$warning_details" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "::warning::Some fields could not be set ($warning_count warnings)"
+          else
+            echo "has_warnings=false" >> $GITHUB_OUTPUT
+          fi
+
+          # Check if command succeeded (exit code 0 = full success, exit code 1 with projectItemId = partial success)
+          project_item_id=$(echo "$result" | jq -r '.projectItemId // ""')
+          error=$(echo "$result" | jq -r '.error // ""')
+
+          if [ $exit_code -ne 0 ]; then
+            if [ -n "$project_item_id" ] && [ "$project_item_id" != "null" ]; then
+              # Partial success: issue was added but some fields failed
+              echo "::warning::Issue added to project but some fields could not be set"
+              exit 1  # Still fail to notify user
+            else
+              # Complete failure: issue was not added
+              echo "::error::CLI exited with code $exit_code"
+              if [ -n "$error" ]; then
+                echo "::error::$error"
+              fi
+              exit 1
+            fi
+          fi
 
       - name: Log success
         run: |
@@ -94,17 +112,37 @@ jobs:
         uses: actions/github-script@v7
         env:
           PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          HAS_WARNINGS: ${{ steps.link-issue.outputs.has_warnings }}
+          WARNING_DETAILS: ${{ steps.link-issue.outputs.warning_details }}
+          PROJECT_ITEM_ID: ${{ steps.link-issue.outputs.project_item_id }}
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const hasWarnings = process.env.HAS_WARNINGS === 'true';
+            const warningDetails = process.env.WARNING_DETAILS || '';
+            const projectItemId = process.env.PROJECT_ITEM_ID || '';
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: [
-                ':warning: **Failed to add this issue to the project**',
+            let body;
+            if (hasWarnings && projectItemId) {
+              // Partial success: issue added but some fields failed
+              body = [
+                ':warning: **Issue added to project but some fields could not be set**',
+                '',
+                '**Field warnings**:',
+                warningDetails,
+                '',
+                '**Troubleshooting**:',
+                '- Verify field names in `.github/project.toml` match your GitHub Project fields',
+                '- Check that single-select options exist in your project',
+                '- Ensure iteration names match active iterations',
+                '',
+                `[View workflow run](${runUrl})`
+              ].join('\n');
+            } else {
+              // Complete failure: issue not added
+              body = [
+                ':x: **Failed to add this issue to the project**',
                 '',
                 '**Troubleshooting**:',
                 '- Ensure `PROJECT_TOKEN` secret is configured with `project` scope',
@@ -112,5 +150,12 @@ jobs:
                 '- Check that the token owner has access to the project',
                 '',
                 `[View workflow run](${runUrl})`
-              ].join('\n')
+              ].join('\n');
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body
             });

--- a/src/cli/commands/link-issue.ts
+++ b/src/cli/commands/link-issue.ts
@@ -23,6 +23,15 @@ import {
 } from '../../lib/github-project.ts';
 
 /**
+ * Warning about field setting failure
+ */
+interface FieldWarning {
+  field: string;
+  reason: string;
+  configuredValue?: string;
+}
+
+/**
  * Result of the link-issue operation
  */
 interface LinkIssueResult {
@@ -31,6 +40,7 @@ interface LinkIssueResult {
   projectItemId?: string;
   projectTitle?: string;
   fieldsSet?: string[];
+  fieldWarnings?: FieldWarning[];
   error?: string;
   context?: {
     repo: string;
@@ -219,27 +229,60 @@ async function linkIssueAction(ctx: CommandContext): Promise<void> {
 
     // Set default field values
     const fieldsSet: string[] = [];
+    const fieldWarnings: FieldWarning[] = [];
+
+    // Helper to add warning
+    const addWarning = (field: string, reason: string, configuredValue?: string) => {
+      fieldWarnings.push({ field, reason, configuredValue });
+      debugLog(
+        `Warning: ${field} - ${reason}${
+          configuredValue ? ` (configured: ${configuredValue})` : ''
+        }`,
+        verbose,
+        jsonOutput,
+      );
+    };
+
+    // Log available fields for debugging
+    debugLog(
+      `Available fields in project: ${
+        project.fields.map((f) => `${f.name}(${f.type || 'unknown'})`).join(', ')
+      }`,
+      verbose,
+      jsonOutput,
+    );
 
     // Set Status
     if (defaults.status) {
       const statusField = findField(project.fields, 'Status');
       if (statusField) {
-        const option = findOption(statusField, defaults.status);
-        if (option) {
-          debugLog(`Setting Status to: ${defaults.status}`, verbose, jsonOutput);
-          await updateItemField(
-            {
-              projectId: project.id,
-              itemId,
-              fieldId: statusField.id,
-              value: { singleSelectOptionId: option.id },
-            },
-            token,
-          );
-          fieldsSet.push('Status');
+        if (statusField.options && statusField.options.length > 0) {
+          const option = findOption(statusField, defaults.status);
+          if (option) {
+            debugLog(`Setting Status to: ${defaults.status}`, verbose, jsonOutput);
+            await updateItemField(
+              {
+                projectId: project.id,
+                itemId,
+                fieldId: statusField.id,
+                value: { singleSelectOptionId: option.id },
+              },
+              token,
+            );
+            fieldsSet.push('Status');
+          } else {
+            const availableOptions = statusField.options.map((o) => o.name).join(', ');
+            addWarning(
+              'Status',
+              `Option '${defaults.status}' not found. Available: ${availableOptions}`,
+              defaults.status,
+            );
+          }
         } else {
-          debugLog(`Warning: Status option '${defaults.status}' not found`, verbose, jsonOutput);
+          addWarning('Status', 'Field has no options configured', defaults.status);
         }
+      } else {
+        addWarning('Status', 'Field not found in project', defaults.status);
       }
     }
 
@@ -247,53 +290,67 @@ async function linkIssueAction(ctx: CommandContext): Promise<void> {
     if (defaults.priority) {
       const priorityField = findField(project.fields, 'Priority');
       if (priorityField) {
-        const option = findOption(priorityField, defaults.priority);
-        if (option) {
-          debugLog(`Setting Priority to: ${defaults.priority}`, verbose, jsonOutput);
-          await updateItemField(
-            {
-              projectId: project.id,
-              itemId,
-              fieldId: priorityField.id,
-              value: { singleSelectOptionId: option.id },
-            },
-            token,
-          );
-          fieldsSet.push('Priority');
+        if (priorityField.options && priorityField.options.length > 0) {
+          const option = findOption(priorityField, defaults.priority);
+          if (option) {
+            debugLog(`Setting Priority to: ${defaults.priority}`, verbose, jsonOutput);
+            await updateItemField(
+              {
+                projectId: project.id,
+                itemId,
+                fieldId: priorityField.id,
+                value: { singleSelectOptionId: option.id },
+              },
+              token,
+            );
+            fieldsSet.push('Priority');
+          } else {
+            const availableOptions = priorityField.options.map((o) => o.name).join(', ');
+            addWarning(
+              'Priority',
+              `Option '${defaults.priority}' not found. Available: ${availableOptions}`,
+              defaults.priority,
+            );
+          }
         } else {
-          debugLog(
-            `Warning: Priority option '${defaults.priority}' not found`,
-            verbose,
-            jsonOutput,
-          );
+          addWarning('Priority', 'Field has no options configured', defaults.priority);
         }
+      } else {
+        addWarning('Priority', 'Field not found in project', defaults.priority);
       }
     }
 
     // Set Iteration
     if (defaults.iteration) {
       const iterationField = findField(project.fields, 'Iteration');
-      if (iterationField?.iterations) {
-        const iteration = findIteration(iterationField, defaults.iteration);
-        if (iteration) {
-          debugLog(`Setting Iteration to: ${defaults.iteration}`, verbose, jsonOutput);
-          await updateItemField(
-            {
-              projectId: project.id,
-              itemId,
-              fieldId: iterationField.id,
-              value: { iterationId: iteration.id },
-            },
-            token,
-          );
-          fieldsSet.push('Iteration');
+      if (iterationField) {
+        if (iterationField.iterations && iterationField.iterations.length > 0) {
+          const iteration = findIteration(iterationField, defaults.iteration);
+          if (iteration) {
+            debugLog(`Setting Iteration to: ${defaults.iteration}`, verbose, jsonOutput);
+            await updateItemField(
+              {
+                projectId: project.id,
+                itemId,
+                fieldId: iterationField.id,
+                value: { iterationId: iteration.id },
+              },
+              token,
+            );
+            fieldsSet.push('Iteration');
+          } else {
+            const availableIterations = iterationField.iterations.map((i) => i.title).join(', ');
+            addWarning(
+              'Iteration',
+              `Iteration '${defaults.iteration}' not found. Available: ${availableIterations}`,
+              defaults.iteration,
+            );
+          }
         } else {
-          debugLog(
-            `Warning: Iteration '${defaults.iteration}' not found`,
-            verbose,
-            jsonOutput,
-          );
+          addWarning('Iteration', 'Field has no iterations configured', defaults.iteration);
         }
+      } else {
+        addWarning('Iteration', 'Field not found in project', defaults.iteration);
       }
     }
 
@@ -312,6 +369,8 @@ async function linkIssueAction(ctx: CommandContext): Promise<void> {
           token,
         );
         fieldsSet.push('Size');
+      } else {
+        addWarning('Size', 'Field not found in project', String(defaults.size));
       }
     }
 
@@ -330,6 +389,8 @@ async function linkIssueAction(ctx: CommandContext): Promise<void> {
           token,
         );
         fieldsSet.push('Estimate');
+      } else {
+        addWarning('Estimate', 'Field not found in project', String(defaults.estimate));
       }
     }
 
@@ -348,6 +409,8 @@ async function linkIssueAction(ctx: CommandContext): Promise<void> {
           token,
         );
         fieldsSet.push('Start date');
+      } else {
+        addWarning('Start date', 'Field not found in project', defaults.startDate);
       }
     }
 
@@ -366,15 +429,20 @@ async function linkIssueAction(ctx: CommandContext): Promise<void> {
           token,
         );
         fieldsSet.push('Target date');
+      } else {
+        addWarning('Target date', 'Field not found in project', defaults.targetDate);
       }
     }
 
+    // Determine success based on whether all configured fields were set
+    const hasWarnings = fieldWarnings.length > 0;
     const result: LinkIssueResult = {
-      success: true,
+      success: !hasWarnings, // Only fully successful if no warnings
       issueNumber,
       projectItemId: itemId,
       projectTitle: project.title,
       fieldsSet,
+      fieldWarnings: hasWarnings ? fieldWarnings : undefined,
     };
 
     // Output
@@ -389,11 +457,27 @@ async function linkIssueAction(ctx: CommandContext): Promise<void> {
       if (fieldsSet.length > 0) {
         console.log(`${colors.muted('Fields set:')} ${fieldsSet.join(', ')}`);
       }
+      if (hasWarnings) {
+        console.log();
+        console.log(colors.warn('⚠ Field warnings:'));
+        for (const warning of fieldWarnings) {
+          console.log(colors.warn(`  - ${warning.field}: ${warning.reason}`));
+        }
+      }
       console.log();
-      console.log(colors.success(`✓ Issue #${issueNumber} added to project`));
+      if (hasWarnings) {
+        console.log(colors.warn(`⚠ Issue #${issueNumber} added to project with warnings`));
+      } else {
+        console.log(colors.success(`✓ Issue #${issueNumber} added to project`));
+      }
     }
 
     debugLog('Link-issue command completed successfully', verbose, jsonOutput);
+
+    // Exit with error code if there were warnings (so workflow can detect partial failure)
+    if (hasWarnings) {
+      Deno.exit(1);
+    }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     debugLog(`Error occurred: ${errorMessage}`, verbose, jsonOutput);

--- a/src/lib/github-project.ts
+++ b/src/lib/github-project.ts
@@ -178,6 +178,35 @@ export function getGitHubToken(): string {
 export async function getProject(projectUrl: string, token: string): Promise<Project> {
   const projectInfo = parseProjectUrl(projectUrl);
 
+  // Common field fragments for all project field types
+  const fieldFragments = `
+    ... on ProjectV2Field {
+      id
+      name
+      dataType
+    }
+    ... on ProjectV2SingleSelectField {
+      id
+      name
+      dataType
+      options {
+        id
+        name
+      }
+    }
+    ... on ProjectV2IterationField {
+      id
+      name
+      dataType
+      configuration {
+        iterations {
+          id
+          title
+        }
+      }
+    }
+  `;
+
   const query = projectInfo.isOrg
     ? `
       query($owner: String!, $number: Int!) {
@@ -187,28 +216,7 @@ export async function getProject(projectUrl: string, token: string): Promise<Pro
             title
             fields(first: 50) {
               nodes {
-                ... on ProjectV2Field {
-                  id
-                  name
-                }
-                ... on ProjectV2SingleSelectField {
-                  id
-                  name
-                  options {
-                    id
-                    name
-                  }
-                }
-                ... on ProjectV2IterationField {
-                  id
-                  name
-                  configuration {
-                    iterations {
-                      id
-                      title
-                    }
-                  }
-                }
+                ${fieldFragments}
               }
             }
           }
@@ -223,28 +231,7 @@ export async function getProject(projectUrl: string, token: string): Promise<Pro
             title
             fields(first: 50) {
               nodes {
-                ... on ProjectV2Field {
-                  id
-                  name
-                }
-                ... on ProjectV2SingleSelectField {
-                  id
-                  name
-                  options {
-                    id
-                    name
-                  }
-                }
-                ... on ProjectV2IterationField {
-                  id
-                  name
-                  configuration {
-                    iterations {
-                      id
-                      title
-                    }
-                  }
-                }
+                ${fieldFragments}
               }
             }
           }
@@ -252,20 +239,23 @@ export async function getProject(projectUrl: string, token: string): Promise<Pro
       }
     `;
 
+  interface FieldNode {
+    id: string;
+    name: string;
+    dataType?: ProjectFieldType;
+    options?: Array<{ id: string; name: string }>;
+    configuration?: {
+      iterations: Array<{ id: string; title: string }>;
+    };
+  }
+
   interface ProjectQueryResult {
     organization?: {
       projectV2: {
         id: string;
         title: string;
         fields: {
-          nodes: Array<{
-            id: string;
-            name: string;
-            options?: Array<{ id: string; name: string }>;
-            configuration?: {
-              iterations: Array<{ id: string; title: string }>;
-            };
-          }>;
+          nodes: FieldNode[];
         };
       };
     };
@@ -274,14 +264,7 @@ export async function getProject(projectUrl: string, token: string): Promise<Pro
         id: string;
         title: string;
         fields: {
-          nodes: Array<{
-            id: string;
-            name: string;
-            options?: Array<{ id: string; name: string }>;
-            configuration?: {
-              iterations: Array<{ id: string; title: string }>;
-            };
-          }>;
+          nodes: FieldNode[];
         };
       };
     };
@@ -305,6 +288,7 @@ export async function getProject(projectUrl: string, token: string): Promise<Pro
     .map((f) => ({
       id: f.id,
       name: f.name,
+      type: f.dataType,
       options: f.options,
       iterations: f.configuration?.iterations,
     }));

--- a/src/templates/issue-to-project.yml
+++ b/src/templates/issue-to-project.yml
@@ -50,38 +50,56 @@ jobs:
           echo "$result"
           echo "::endgroup::"
 
-          # Check if command succeeded
-          if [ $exit_code -ne 0 ]; then
-            echo "::error::CLI exited with code $exit_code"
-            echo "result=$result" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-
           # Validate JSON before parsing
           if ! echo "$result" | jq -e . > /dev/null 2>&1; then
             echo "::error::Invalid JSON output from CLI"
             echo "Raw output: $result"
+            echo "result={}" >> $GITHUB_OUTPUT
+            echo "has_warnings=false" >> $GITHUB_OUTPUT
             exit 1
           fi
 
           echo "result=$result" >> $GITHUB_OUTPUT
 
-          # Parse result safely with defaults
-          success=$(echo "$result" | jq -r '.success // "false"')
-          if [ "$success" != "true" ]; then
-            error=$(echo "$result" | jq -r '.error // "Unknown error"')
-            context=$(echo "$result" | jq -r '.context // empty')
-            echo "::error::Link-issue failed: $error"
-            if [ -n "$context" ]; then
-              echo "Context: $context"
-            fi
-            exit 1
-          fi
-
           # Extract values for logging
           echo "project_title=$(echo "$result" | jq -r '.projectTitle // ""')" >> $GITHUB_OUTPUT
           echo "project_item_id=$(echo "$result" | jq -r '.projectItemId // ""')" >> $GITHUB_OUTPUT
           echo "fields_set=$(echo "$result" | jq -r '.fieldsSet // [] | join(", ")')" >> $GITHUB_OUTPUT
+
+          # Check for field warnings (partial success)
+          warnings=$(echo "$result" | jq -r '.fieldWarnings // []')
+          warning_count=$(echo "$result" | jq -r '.fieldWarnings // [] | length')
+          if [ "$warning_count" -gt 0 ]; then
+            echo "has_warnings=true" >> $GITHUB_OUTPUT
+            echo "warning_count=$warning_count" >> $GITHUB_OUTPUT
+            # Format warnings for display
+            warning_details=$(echo "$result" | jq -r '.fieldWarnings[] | "- \(.field): \(.reason)"')
+            echo "warning_details<<EOF" >> $GITHUB_OUTPUT
+            echo "$warning_details" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "::warning::Some fields could not be set ($warning_count warnings)"
+          else
+            echo "has_warnings=false" >> $GITHUB_OUTPUT
+          fi
+
+          # Check if command succeeded (exit code 0 = full success, exit code 1 with projectItemId = partial success)
+          project_item_id=$(echo "$result" | jq -r '.projectItemId // ""')
+          error=$(echo "$result" | jq -r '.error // ""')
+
+          if [ $exit_code -ne 0 ]; then
+            if [ -n "$project_item_id" ] && [ "$project_item_id" != "null" ]; then
+              # Partial success: issue was added but some fields failed
+              echo "::warning::Issue added to project but some fields could not be set"
+              exit 1  # Still fail to notify user
+            else
+              # Complete failure: issue was not added
+              echo "::error::CLI exited with code $exit_code"
+              if [ -n "$error" ]; then
+                echo "::error::$error"
+              fi
+              exit 1
+            fi
+          fi
 
       - name: Log success
         run: |
@@ -94,17 +112,37 @@ jobs:
         uses: actions/github-script@v7
         env:
           PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          HAS_WARNINGS: ${{ steps.link-issue.outputs.has_warnings }}
+          WARNING_DETAILS: ${{ steps.link-issue.outputs.warning_details }}
+          PROJECT_ITEM_ID: ${{ steps.link-issue.outputs.project_item_id }}
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const hasWarnings = process.env.HAS_WARNINGS === 'true';
+            const warningDetails = process.env.WARNING_DETAILS || '';
+            const projectItemId = process.env.PROJECT_ITEM_ID || '';
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: [
-                ':warning: **Failed to add this issue to the project**',
+            let body;
+            if (hasWarnings && projectItemId) {
+              // Partial success: issue added but some fields failed
+              body = [
+                ':warning: **Issue added to project but some fields could not be set**',
+                '',
+                '**Field warnings**:',
+                warningDetails,
+                '',
+                '**Troubleshooting**:',
+                '- Verify field names in `.github/project.toml` match your GitHub Project fields',
+                '- Check that single-select options exist in your project',
+                '- Ensure iteration names match active iterations',
+                '',
+                `[View workflow run](${runUrl})`
+              ].join('\n');
+            } else {
+              // Complete failure: issue not added
+              body = [
+                ':x: **Failed to add this issue to the project**',
                 '',
                 '**Troubleshooting**:',
                 '- Ensure `PROJECT_TOKEN` secret is configured with `project` scope',
@@ -112,5 +150,12 @@ jobs:
                 '- Check that the token owner has access to the project',
                 '',
                 `[View workflow run](${runUrl})`
-              ].join('\n')
+              ].join('\n');
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body
             });


### PR DESCRIPTION
## 概要

`issue-to-project.yml` ワークフロー実行時に、GitHub Project のフィールド初期値が設定されない問題を修正しました。

## 変更内容

### 🐛 バグ修正

- GraphQL クエリに `dataType` フィールドを追加し、フィールド型情報を正しく取得
- フィールドフラグメントを共通化して重複を削減

### ✨ 機能追加

- `FieldWarning` インターフェースを追加し、フィールド設定失敗の詳細を追跡
- フィールド/オプションが見つからない場合、利用可能な選択肢を表示
- JSON出力に `fieldWarnings` を含め、CI/CDパイプラインでの検出を可能に

### ♻️ リファクタリング

- ワークフローで部分的成功（Issue追加済みだがフィールド設定失敗）と完全失敗を区別
- GitHub Issue コメントに詳細なトラブルシューティング情報を追加

## 技術的詳細

### GraphQL クエリの改善

```graphql
... on ProjectV2Field {
  id
  name
  dataType  # 追加
}
... on ProjectV2SingleSelectField {
  id
  name
  dataType  # 追加
  options { id name }
}
```

### エラーハンドリングの改善

フィールド設定に失敗した場合、以下の情報を含む警告を出力:
- 失敗したフィールド名
- 失敗の理由
- 設定しようとした値
- 利用可能な選択肢（該当する場合）

### 出力例

```json
{
  "success": false,
  "projectItemId": "PVTI_xxx",
  "fieldsSet": ["Status"],
  "fieldWarnings": [
    {
      "field": "Priority",
      "reason": "Option 'P1' not found. Available: High, Medium, Low",
      "configuredValue": "P1"
    }
  ]
}
```

## テスト

- [x] ユニットテスト実施
- [x] 型チェック通過 (deno check)
- [x] Lintチェック通過 (deno lint)
- [x] フォーマットチェック通過 (deno fmt)

## チェックリスト

- [x] コードレビュー準備完了
- [x] Lintチェック通過
- [x] フォーマットチェック通過
- [x] 型チェック通過
- [x] 全テスト成功

## 関連Issue

Closes #15

## その他

フィールド名はGitHub Projectの設定と完全に一致する必要があります（大文字/小文字は区別されません）。