### PR TITLE
fix: handle non-existent issues gracefully in pr-status workflow

### DIFF
--- a/.github/workflows/pr-status-update.yml
+++ b/.github/workflows/pr-status-update.yml
@@ -106,20 +106,26 @@ jobs:
           # Extract values for logging/comment
           echo "processed_issues=$(echo "$result" | jq -r '.processedIssues // [] | map("#" + tostring) | join(", ")')" >> $GITHUB_OUTPUT
           echo "failed_issues=$(echo "$result" | jq -r '.failedIssues // [] | map("#" + tostring) | join(", ")')" >> $GITHUB_OUTPUT
+          echo "skipped_issues=$(echo "$result" | jq -r '.skippedIssues // [] | map("#" + tostring) | join(", ")')" >> $GITHUB_OUTPUT
           echo "new_status=$(echo "$result" | jq -r '.newStatus // ""')" >> $GITHUB_OUTPUT
           echo "processed_count=$(echo "$result" | jq -r '.processedIssues | length')" >> $GITHUB_OUTPUT
           echo "failed_count=$(echo "$result" | jq -r '.failedIssues | length')" >> $GITHUB_OUTPUT
+          echo "skipped_count=$(echo "$result" | jq -r '.skippedIssues | length')" >> $GITHUB_OUTPUT
+          echo "issue_source=$(echo "$result" | jq -c '.issueSource // {}')" >> $GITHUB_OUTPUT
 
       - name: Log success
         if: steps.pr-status.outputs.processed_count != '0'
         run: |
           echo "✓ Updated status to '${{ steps.pr-status.outputs.new_status }}' for issues: ${{ steps.pr-status.outputs.processed_issues }}"
+          if [ -n "${{ steps.pr-status.outputs.skipped_issues }}" ]; then
+            echo "⚠ Skipped (not found): ${{ steps.pr-status.outputs.skipped_issues }}"
+          fi
           if [ -n "${{ steps.pr-status.outputs.failed_issues }}" ]; then
             echo "✗ Failed to update: ${{ steps.pr-status.outputs.failed_issues }}"
           fi
 
       - name: Comment on PR (no issues found)
-        if: steps.pr-status.outputs.processed_count == '0' && steps.pr-status.outputs.failed_count == '0'
+        if: steps.pr-status.outputs.processed_count == '0' && steps.pr-status.outputs.failed_count == '0' && steps.pr-status.outputs.skipped_count == '0'
         uses: actions/github-script@v7
         with:
           script: |
@@ -142,6 +148,49 @@ jobs:
                 '- Branch: `label/author/{issue_number}/title`',
                 '- Keywords: `Closes #N`, `Fixes #N`, `Resolves #N`'
               ].join('\n')
+            });
+
+      - name: Warn if all issues skipped
+        if: steps.pr-status.outputs.processed_count == '0' && steps.pr-status.outputs.skipped_count != '0'
+        run: |
+          echo "::warning::All extracted issues were skipped (not found in repository)"
+
+      - name: Comment on PR (issues skipped)
+        if: steps.pr-status.outputs.skipped_count != '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branchName = '${{ github.head_ref }}';
+            const processed = '${{ steps.pr-status.outputs.processed_issues }}';
+            const skipped = '${{ steps.pr-status.outputs.skipped_issues }}';
+            const newStatus = '${{ steps.pr-status.outputs.new_status }}';
+            const issueSource = JSON.parse('${{ steps.pr-status.outputs.issue_source }}' || '{}');
+
+            // Build skipped issues with source info
+            const skippedList = skipped.split(', ').filter(Boolean).map(issue => {
+              const num = issue.replace('#', '');
+              const source = issueSource[num] || 'unknown';
+              return `${issue} (not found - extracted from ${source})`;
+            });
+
+            const bodyLines = [':clipboard: **PR Status Update**', ''];
+
+            if (processed) {
+              bodyLines.push(`**:white_check_mark: Updated:** ${processed} → ${newStatus}`);
+            }
+
+            if (skippedList.length > 0) {
+              bodyLines.push(`**:warning: Skipped:**`);
+              skippedList.forEach(item => bodyLines.push(`- ${item}`));
+            }
+
+            bodyLines.push('', `**Source branch:** \`${branchName}\``);
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: bodyLines.join('\n')
             });
 
       - name: Handle partial failure

--- a/src/cli/commands/pr-status.ts
+++ b/src/cli/commands/pr-status.ts
@@ -23,6 +23,11 @@ import {
 } from '../../lib/github-project.ts';
 
 /**
+ * Source of where an issue number was extracted from
+ */
+type IssueSource = 'branch' | 'body';
+
+/**
  * Result of the pr-status operation
  */
 interface PrStatusResult {
@@ -34,6 +39,8 @@ interface PrStatusResult {
   newStatus: string;
   isDraft: boolean;
   skippedDraft: boolean;
+  /** Map of issue number to extraction source (branch or body) */
+  issueSource?: Record<number, IssueSource>;
   error?: string;
   context?: {
     repo: string;
@@ -292,7 +299,7 @@ async function prStatusAction(ctx: CommandContext): Promise<void> {
       return;
     }
 
-    // Extract issue numbers
+    // Extract issue numbers and track their sources
     debugLog(`Extracting issues from branch: ${branch}`, verbose, jsonOutput);
     const branchIssues = extractFromBranch(branch, prConfig.branchPattern);
     debugLog(`Issues from branch: ${branchIssues.join(', ') || 'none'}`, verbose, jsonOutput);
@@ -301,8 +308,19 @@ async function prStatusAction(ctx: CommandContext): Promise<void> {
     const bodyIssues = extractFromBody(body);
     debugLog(`Issues from body: ${bodyIssues.join(', ') || 'none'}`, verbose, jsonOutput);
 
+    // Track issue sources (branch takes precedence for duplicates)
+    const issueSourceMap = new Map<number, IssueSource>();
+    for (const issue of branchIssues) {
+      issueSourceMap.set(issue, 'branch');
+    }
+    for (const issue of bodyIssues) {
+      if (!issueSourceMap.has(issue)) {
+        issueSourceMap.set(issue, 'body');
+      }
+    }
+
     // Combine and deduplicate
-    const allIssues = [...new Set([...branchIssues, ...bodyIssues])];
+    const allIssues = [...issueSourceMap.keys()];
     debugLog(`All issues to process: ${allIssues.join(', ') || 'none'}`, verbose, jsonOutput);
 
     if (allIssues.length === 0) {
@@ -315,6 +333,7 @@ async function prStatusAction(ctx: CommandContext): Promise<void> {
         newStatus: prConfig.reviewStatus,
         isDraft,
         skippedDraft: false,
+        issueSource: {},
       };
 
       if (jsonOutput) {
@@ -412,8 +431,21 @@ async function prStatusAction(ctx: CommandContext): Promise<void> {
       } catch (issueError) {
         const errorMsg = issueError instanceof Error ? issueError.message : String(issueError);
         debugLog(`Error processing Issue #${issueNumber}: ${errorMsg}`, verbose, jsonOutput);
-        failedIssues.push(issueNumber);
+
+        // Check if error is "not found" - treat as skipped, not failed
+        if (errorMsg.includes('not found')) {
+          debugLog(`Issue #${issueNumber} not found, adding to skipped`, verbose, jsonOutput);
+          skippedIssues.push(issueNumber);
+        } else {
+          failedIssues.push(issueNumber);
+        }
       }
+    }
+
+    // Convert issueSourceMap to plain object for JSON output
+    const issueSource: Record<number, IssueSource> = {};
+    for (const [issue, source] of issueSourceMap) {
+      issueSource[issue] = source;
     }
 
     const result: PrStatusResult = {
@@ -425,6 +457,7 @@ async function prStatusAction(ctx: CommandContext): Promise<void> {
       newStatus: prConfig.reviewStatus,
       isDraft,
       skippedDraft: false,
+      issueSource,
     };
 
     // Output
@@ -442,6 +475,12 @@ async function prStatusAction(ctx: CommandContext): Promise<void> {
       if (processedIssues.length > 0) {
         console.log(
           `  ${colors.success('✓')} ${processedIssues.map((i) => `#${i}`).join(', ')}`,
+        );
+      }
+      if (skippedIssues.length > 0) {
+        console.log(`${colors.muted('Skipped:')} ${skippedIssues.length} issues (not found)`);
+        console.log(
+          `  ${colors.warn('⚠')} ${skippedIssues.map((i) => `#${i}`).join(', ')}`,
         );
       }
       if (failedIssues.length > 0) {

--- a/src/templates/pr-status-update.yml
+++ b/src/templates/pr-status-update.yml
@@ -106,20 +106,26 @@ jobs:
           # Extract values for logging/comment
           echo "processed_issues=$(echo "$result" | jq -r '.processedIssues // [] | map("#" + tostring) | join(", ")')" >> $GITHUB_OUTPUT
           echo "failed_issues=$(echo "$result" | jq -r '.failedIssues // [] | map("#" + tostring) | join(", ")')" >> $GITHUB_OUTPUT
+          echo "skipped_issues=$(echo "$result" | jq -r '.skippedIssues // [] | map("#" + tostring) | join(", ")')" >> $GITHUB_OUTPUT
           echo "new_status=$(echo "$result" | jq -r '.newStatus // ""')" >> $GITHUB_OUTPUT
           echo "processed_count=$(echo "$result" | jq -r '.processedIssues | length')" >> $GITHUB_OUTPUT
           echo "failed_count=$(echo "$result" | jq -r '.failedIssues | length')" >> $GITHUB_OUTPUT
+          echo "skipped_count=$(echo "$result" | jq -r '.skippedIssues | length')" >> $GITHUB_OUTPUT
+          echo "issue_source=$(echo "$result" | jq -c '.issueSource // {}')" >> $GITHUB_OUTPUT
 
       - name: Log success
         if: steps.pr-status.outputs.processed_count != '0'
         run: |
           echo "✓ Updated status to '${{ steps.pr-status.outputs.new_status }}' for issues: ${{ steps.pr-status.outputs.processed_issues }}"
+          if [ -n "${{ steps.pr-status.outputs.skipped_issues }}" ]; then
+            echo "⚠ Skipped (not found): ${{ steps.pr-status.outputs.skipped_issues }}"
+          fi
           if [ -n "${{ steps.pr-status.outputs.failed_issues }}" ]; then
             echo "✗ Failed to update: ${{ steps.pr-status.outputs.failed_issues }}"
           fi
 
       - name: Comment on PR (no issues found)
-        if: steps.pr-status.outputs.processed_count == '0' && steps.pr-status.outputs.failed_count == '0'
+        if: steps.pr-status.outputs.processed_count == '0' && steps.pr-status.outputs.failed_count == '0' && steps.pr-status.outputs.skipped_count == '0'
         uses: actions/github-script@v7
         with:
           script: |
@@ -142,6 +148,49 @@ jobs:
                 '- Branch: `label/author/{issue_number}/title`',
                 '- Keywords: `Closes #N`, `Fixes #N`, `Resolves #N`'
               ].join('\n')
+            });
+
+      - name: Warn if all issues skipped
+        if: steps.pr-status.outputs.processed_count == '0' && steps.pr-status.outputs.skipped_count != '0'
+        run: |
+          echo "::warning::All extracted issues were skipped (not found in repository)"
+
+      - name: Comment on PR (issues skipped)
+        if: steps.pr-status.outputs.skipped_count != '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branchName = '${{ github.head_ref }}';
+            const processed = '${{ steps.pr-status.outputs.processed_issues }}';
+            const skipped = '${{ steps.pr-status.outputs.skipped_issues }}';
+            const newStatus = '${{ steps.pr-status.outputs.new_status }}';
+            const issueSource = JSON.parse('${{ steps.pr-status.outputs.issue_source }}' || '{}');
+
+            // Build skipped issues with source info
+            const skippedList = skipped.split(', ').filter(Boolean).map(issue => {
+              const num = issue.replace('#', '');
+              const source = issueSource[num] || 'unknown';
+              return `${issue} (not found - extracted from ${source})`;
+            });
+
+            const bodyLines = [':clipboard: **PR Status Update**', ''];
+
+            if (processed) {
+              bodyLines.push(`**:white_check_mark: Updated:** ${processed} → ${newStatus}`);
+            }
+
+            if (skippedList.length > 0) {
+              bodyLines.push(`**:warning: Skipped:**`);
+              skippedList.forEach(item => bodyLines.push(`- ${item}`));
+            }
+
+            bodyLines.push('', `**Source branch:** \`${branchName}\``);
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: bodyLines.join('\n')
             });
 
       - name: Handle partial failure


### PR DESCRIPTION
## 概要

`pr-status-update.yml` ワークフロー実行時、PRから抽出されたIssue番号が実際には存在しない場合にエラー終了してしまう問題を修正しました。存在しないIssueは `skippedIssues` として記録し、正常終了するように改善しました。

## 変更内容

### 🐛 バグ修正

- 存在しないIssueを `failedIssues` ではなく `skippedIssues` に分類するよう変更
- 全体の `success` 判定は `failedIssues` のみで行う（`skippedIssues` は成功扱い）

### ✨ 新機能

- `IssueSource` 型を追加し、Issue番号の抽出元（branch/body）を追跡
- JSON出力に `issueSource` フィールドを追加
- ワークフローに `skipped_count`, `issue_source` 出力を追加
- 全Issueがスキップされた場合に warning アノテーションを表示
- スキップ情報を含む詳細なPRコメントを投稿（抽出元も表示）

## 技術的詳細

### CLI側 (`src/cli/commands/pr-status.ts`)

```typescript
// エラー分類ロジック
if (errorMsg.includes('not found')) {
  skippedIssues.push(issueNumber);  // スキップ扱い
} else {
  failedIssues.push(issueNumber);   // 失敗扱い
}

// Issue抽出元の追跡
const issueSourceMap = new Map<number, IssueSource>();
for (const issue of branchIssues) {
  issueSourceMap.set(issue, 'branch');
}
for (const issue of bodyIssues) {
  if (!issueSourceMap.has(issue)) {
    issueSourceMap.set(issue, 'body');
  }
}
```

### Workflow側

- `skipped_issues`, `skipped_count`, `issue_source` 出力を追加
- 「Warn if all issues skipped」ステップを追加
- 「Comment on PR (issues skipped)」ステップを追加

### PRコメント形式

```
📋 PR Status Update

✓ Updated: #123 → In Review
⚠️ Skipped:
- #456 (not found - extracted from body)

Source branch: `feature/user/123/add-feature`
```

## テスト

- [x] 既存のユニットテスト（extractFromBranch, extractFromBody）は変更なし
- [ ] 手動テスト: 存在しないIssue番号を含むPRでワークフローをトリガー

## チェックリスト

- [x] コードレビュー準備完了
- [ ] Lintチェック通過 (deno lint)
- [ ] フォーマットチェック通過 (deno fmt)
- [ ] 型チェック通過 (deno check)
- [ ] 全テスト成功 (deno test)

## 関連Issue

Closes #16

## その他

- `skippedIssues` フィールドは既に `PrStatusResult` に存在していましたが、今回から実際に活用されるようになりました
- 将来的にスキップ理由の詳細化（権限不足等）を行う場合は、`issueSource` の構造を拡張する予定