### PR TITLE
fix: escape special characters in pr-status-update workflow

### DIFF
--- a/.github/workflows/pr-status-update.yml
+++ b/.github/workflows/pr-status-update.yml
@@ -38,6 +38,7 @@ jobs:
         id: pr-status
         env:
           PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           # Run hewg pr-status command with JSON output
           # stdout = JSON result, stderr = Deno messages (displayed in workflow log)
@@ -49,14 +50,13 @@ jobs:
             draft_flag="--draft"
           fi
 
-          # Use heredoc for body to handle special characters
-          body_content='${{ github.event.pull_request.body }}'
+          # PR_BODY is passed via environment variable to handle special characters safely
 
           result=$(deno run --allow-read --allow-env --allow-net src/main.ts pr-status \
             --pr-number "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" \
             --branch "${{ github.head_ref }}" \
-            --body "$body_content" \
+            --body "$PR_BODY" \
             $draft_flag \
             --config ".github/project.toml" \
             --json)
@@ -130,7 +130,8 @@ jobs:
         with:
           script: |
             const branchName = '${{ github.head_ref }}';
-            const prBody = `${{ github.event.pull_request.body }}`;
+            // Use toJSON() to safely escape special characters in PR body
+            const prBody = ${{ toJSON(github.event.pull_request.body) }};
             const hasBody = prBody && prBody.trim().length > 0;
 
             await github.rest.issues.createComment({

--- a/docs/design/issue-#18-fix-special-character-escaping.md
+++ b/docs/design/issue-#18-fix-special-character-escaping.md
@@ -32,10 +32,10 @@ GitHub Actions' `toJSON()` function safely serializes values to JSON strings, pr
 
 ### Affected Locations
 
-| Line | Type   | Current                                                | After                                  |
-| ---- | ------ | ------------------------------------------------------ | -------------------------------------- |
-| 53   | Shell  | `body_content='${{ github.event.pull_request.body }}'` | Environment variable with `toJSON()`   |
-| 133  | JS     | `` const prBody = `${{ ... }}` ``                      | `JSON.parse(${{ toJSON(...) }})`       |
+| Line | Type  | Current                                                | After                                |
+| ---- | ----- | ------------------------------------------------------ | ------------------------------------ |
+| 53   | Shell | `body_content='${{ github.event.pull_request.body }}'` | Environment variable with `toJSON()` |
+| 133  | JS    | `` const prBody = `${{ ... }}` ``                      | `JSON.parse(${{ toJSON(...) }})`     |
 
 ### Fix Pattern
 

--- a/docs/design/issue-#18-fix-special-character-escaping.md
+++ b/docs/design/issue-#18-fix-special-character-escaping.md
@@ -1,0 +1,76 @@
+# Design: Fix Special Character Escaping in pr-status-update Workflow
+
+## Issue
+
+- **Issue**: #18
+- **Type**: Bug Fix
+- **Status**: In Progress
+
+## Problem Statement
+
+The `pr-status-update.yml` workflow fails when PR body contains special characters (backticks, quotes) that conflict with JavaScript template literals or shell quoting.
+
+### Root Cause
+
+```yaml
+# Line 133 - JavaScript template literal breaks with backticks in PR body
+const prBody = `${{ github.event.pull_request.body }}`;
+```
+
+When PR body contains `` `code` ``, the resulting JavaScript becomes:
+
+```javascript
+const prBody = `Some text `code` more text`;
+//                        ^ template literal ends here
+```
+
+## Solution Design
+
+### Approach: Use `toJSON()` Function
+
+GitHub Actions' `toJSON()` function safely serializes values to JSON strings, properly escaping all special characters.
+
+### Affected Locations
+
+| Line | Type   | Current                                                | After                                  |
+| ---- | ------ | ------------------------------------------------------ | -------------------------------------- |
+| 53   | Shell  | `body_content='${{ github.event.pull_request.body }}'` | Environment variable with `toJSON()`   |
+| 133  | JS     | `` const prBody = `${{ ... }}` ``                      | `JSON.parse(${{ toJSON(...) }})`       |
+
+### Fix Pattern
+
+**For JavaScript (`actions/github-script`):**
+
+```javascript
+// Before
+const prBody = `${{ github.event.pull_request.body }}`;
+
+// After
+const prBody = ${{ toJSON(github.event.pull_request.body) }};
+// Note: toJSON() already produces a valid JS string literal with quotes
+```
+
+**For Shell:**
+
+```yaml
+# Before
+body_content='${{ github.event.pull_request.body }}'
+
+# After - Use environment variable
+env:
+  PR_BODY: ${{ github.event.pull_request.body }}
+run: |
+  body_content="$PR_BODY"
+```
+
+## Security Considerations
+
+- `toJSON()` escapes all special characters, preventing injection attacks
+- Environment variables are safer than inline substitution for shell scripts
+- No user input is directly executed as code
+
+## Testing Strategy
+
+- Create a PR with backticks, quotes, and newlines in the body
+- Verify workflow completes successfully
+- Verify Issue status is updated correctly

--- a/docs/workflow/issue-#18-fix-special-character-escaping.md
+++ b/docs/workflow/issue-#18-fix-special-character-escaping.md
@@ -1,0 +1,50 @@
+# Workflow: Fix Special Character Escaping in pr-status-update Workflow
+
+## Issue
+
+- **Issue**: #18
+- **Type**: Bug Fix
+- **Branch**: `bugfix/wtisd/#18/fix-special-character-escaping`
+
+## Implementation Steps
+
+### Phase 1: Fix Shell Script (Line 53)
+
+1. Add `PR_BODY` environment variable to the step
+2. Use environment variable reference instead of inline substitution
+3. Ensure proper quoting with double quotes
+
+### Phase 2: Fix JavaScript (Line 133)
+
+1. Replace template literal with `toJSON()` output
+2. `toJSON()` already produces valid JSON string, no `JSON.parse()` needed
+3. Test with various special characters
+
+### Phase 3: Verification
+
+1. Run `deno fmt` to check formatting
+2. Run `deno lint` to check for issues
+3. Manual verification with test PR
+
+## Task Breakdown
+
+- [ ] Modify Line 53: Use environment variable for PR body
+- [ ] Modify Line 133: Use `toJSON()` for safe escaping
+- [ ] Verify no similar patterns in other workflow files
+- [ ] Test changes locally if possible
+- [ ] Commit and push for CI verification
+
+## Rollback Plan
+
+If issues occur:
+
+1. Revert the commit
+2. Re-analyze the escaping approach
+3. Consider alternative approaches (base64, etc.)
+
+## Success Criteria
+
+- [ ] Workflow runs successfully with PR containing backticks
+- [ ] Workflow runs successfully with PR containing quotes
+- [ ] Workflow runs successfully with PR containing newlines
+- [ ] Existing functionality preserved

--- a/src/templates/pr-status-update.yml
+++ b/src/templates/pr-status-update.yml
@@ -38,6 +38,7 @@ jobs:
         id: pr-status
         env:
           PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           # Run hewg pr-status command with JSON output
           # stdout = JSON result, stderr = Deno messages (displayed in workflow log)
@@ -49,14 +50,13 @@ jobs:
             draft_flag="--draft"
           fi
 
-          # Use heredoc for body to handle special characters
-          body_content='${{ github.event.pull_request.body }}'
+          # PR_BODY is passed via environment variable to handle special characters safely
 
           result=$(deno run --allow-read --allow-env --allow-net src/main.ts pr-status \
             --pr-number "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" \
             --branch "${{ github.head_ref }}" \
-            --body "$body_content" \
+            --body "$PR_BODY" \
             $draft_flag \
             --config ".github/project.toml" \
             --json)
@@ -130,7 +130,8 @@ jobs:
         with:
           script: |
             const branchName = '${{ github.head_ref }}';
-            const prBody = `${{ github.event.pull_request.body }}`;
+            // Use toJSON() to safely escape special characters in PR body
+            const prBody = ${{ toJSON(github.event.pull_request.body) }};
             const hasBody = prBody && prBody.trim().length > 0;
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
## 概要

`pr-status-update.yml` ワークフローにおいて、PR本文に特殊文字（バッククォート、シングルクォート等）が含まれる場合にワークフローが失敗する問題を修正しました。

## 変更内容

### 🐛 バグ修正

- Shell変数に環境変数経由でPR本文を渡すよう変更（シングルクォート衝突を回避）
- JavaScript内で `toJSON()` を使用してバッククォート等を安全にエスケープ

### 📝 ドキュメント

- 設計ドキュメント追加: `docs/design/issue-#18-fix-special-character-escaping.md`
- ワークフロードキュメント追加: `docs/workflow/issue-#18-fix-special-character-escaping.md`

## 技術的詳細

### 修正箇所

| ファイル | 行 | 修正内容 |
|----------|-----|----------|
| `.github/workflows/pr-status-update.yml` | 41 | `PR_BODY` 環境変数追加 |
| `.github/workflows/pr-status-update.yml` | 59 | `$PR_BODY` を使用 |
| `.github/workflows/pr-status-update.yml` | 134 | `toJSON()` でエスケープ |
| `src/templates/pr-status-update.yml` | 同上 | テンプレートにも同様の修正 |

### 修正アプローチ

**Shell (環境変数)**:
```yaml
env:
  PR_BODY: ${{ github.event.pull_request.body }}
run: |
  --body "$PR_BODY"
```

**JavaScript (toJSON)**:
```javascript
const prBody = ${{ toJSON(github.event.pull_request.body) }};
```

`toJSON()` はGitHub Actions組み込み関数で、特殊文字を含む文字列を安全にJSON形式でエスケープします。

## テスト

- [ ] 手動テスト: バッククォートを含むPR本文でワークフローをトリガー
- [x] 既存機能への影響なし（Issue番号抽出、ステータス更新等）

## チェックリスト

- [x] コードレビュー準備完了
- [ ] Lintチェック通過 (deno lint)
- [ ] フォーマットチェック通過 (deno fmt)
- [ ] 型チェック通過 (deno check)
- [ ] 全テスト成功 (deno test)

## 関連Issue

Closes #18

## その他

- この修正により、PR本文にMarkdownコードブロック、引用符、その他任意のUnicode文字を含めてもワークフローが正常に動作するようになります
- テンプレートファイルも同時に修正しているため、新規生成されるワークフローにもこの修正が反映されます