### PR TITLE
feat: add automatic Sprint and Start date assignment to issue-to-project workflow

### DIFF
--- a/.github/project.toml
+++ b/.github/project.toml
@@ -35,6 +35,16 @@ status = "Planned"
 # Target date (YYYY-MM-DD format)
 # target_date = "2026-01-12"
 
+# Dynamic field values (automatically determined at runtime)
+# These are used when static values above are not specified
+
+# Automatically set to current Sprint based on today's date
+# If today is not within any Sprint, uses the closest Sprint
+use_current_iteration = true
+
+# Automatically set to today's date when issue is created
+use_current_date = true
+
 [pr]
 # Pull Request Status Update Configuration
 # These settings control the pr-status-update workflow

--- a/src/cli/commands/link-issue.ts
+++ b/src/cli/commands/link-issue.ts
@@ -16,6 +16,7 @@ import {
   findField,
   findIteration,
   findOption,
+  getCurrentIteration,
   getGitHubToken,
   getIssueNodeId,
   getProject,
@@ -59,6 +60,8 @@ interface DefaultsConfig {
   estimate?: number;
   startDate?: string;
   targetDate?: string;
+  useCurrentIteration?: boolean;
+  useCurrentDate?: boolean;
 }
 
 /**
@@ -155,6 +158,8 @@ async function loadConfig(
     defaults.estimate = config.defaults.estimate as number | undefined;
     defaults.startDate = config.defaults.start_date as string | undefined;
     defaults.targetDate = config.defaults.target_date as string | undefined;
+    defaults.useCurrentIteration = config.defaults.use_current_iteration as boolean | undefined;
+    defaults.useCurrentDate = config.defaults.use_current_date as boolean | undefined;
   }
 
   return {
@@ -320,14 +325,40 @@ async function linkIssueAction(ctx: CommandContext): Promise<void> {
       }
     }
 
-    // Set Iteration
-    if (defaults.iteration) {
+    // Set Iteration (static value takes priority over dynamic)
+    if (defaults.iteration || defaults.useCurrentIteration) {
       const iterationField = findField(project.fields, 'Iteration');
       if (iterationField) {
         if (iterationField.iterations && iterationField.iterations.length > 0) {
-          const iteration = findIteration(iterationField, defaults.iteration);
+          let iteration;
+          let iterationSource: string = '';
+
+          if (defaults.iteration) {
+            // Static iteration specified - use it
+            iteration = findIteration(iterationField, defaults.iteration);
+            iterationSource = defaults.iteration;
+            if (!iteration) {
+              const availableIterations = iterationField.iterations.map((i) => i.title).join(', ');
+              addWarning(
+                'Iteration',
+                `Iteration '${defaults.iteration}' not found. Available: ${availableIterations}`,
+                defaults.iteration,
+              );
+            }
+          } else if (defaults.useCurrentIteration) {
+            // Use current iteration based on date
+            iteration = getCurrentIteration(iterationField);
+            iterationSource = iteration?.title ?? 'current';
+            if (!iteration) {
+              addWarning(
+                'Iteration',
+                'Could not determine current iteration (no iterations with date info)',
+              );
+            }
+          }
+
           if (iteration) {
-            debugLog(`Setting Iteration to: ${defaults.iteration}`, verbose, jsonOutput);
+            debugLog(`Setting Iteration to: ${iterationSource}`, verbose, jsonOutput);
             await updateItemField(
               {
                 projectId: project.id,
@@ -338,19 +369,20 @@ async function linkIssueAction(ctx: CommandContext): Promise<void> {
               token,
             );
             fieldsSet.push('Iteration');
-          } else {
-            const availableIterations = iterationField.iterations.map((i) => i.title).join(', ');
-            addWarning(
-              'Iteration',
-              `Iteration '${defaults.iteration}' not found. Available: ${availableIterations}`,
-              defaults.iteration,
-            );
           }
         } else {
-          addWarning('Iteration', 'Field has no iterations configured', defaults.iteration);
+          addWarning(
+            'Iteration',
+            'Field has no iterations configured',
+            defaults.iteration ?? 'use_current_iteration',
+          );
         }
       } else {
-        addWarning('Iteration', 'Field not found in project', defaults.iteration);
+        addWarning(
+          'Iteration',
+          'Field not found in project',
+          defaults.iteration ?? 'use_current_iteration',
+        );
       }
     }
 
@@ -394,23 +426,38 @@ async function linkIssueAction(ctx: CommandContext): Promise<void> {
       }
     }
 
-    // Set Start date
-    if (defaults.startDate) {
+    // Set Start date (static value takes priority over dynamic)
+    if (defaults.startDate || defaults.useCurrentDate) {
       const startDateField = findField(project.fields, 'Start date');
       if (startDateField) {
-        debugLog(`Setting Start date to: ${defaults.startDate}`, verbose, jsonOutput);
+        let dateValue: string;
+
+        if (defaults.startDate) {
+          // Static date specified - use it
+          dateValue = defaults.startDate;
+        } else {
+          // Use current date (YYYY-MM-DD format)
+          const today = new Date();
+          dateValue = today.toISOString().split('T')[0];
+        }
+
+        debugLog(`Setting Start date to: ${dateValue}`, verbose, jsonOutput);
         await updateItemField(
           {
             projectId: project.id,
             itemId,
             fieldId: startDateField.id,
-            value: { date: defaults.startDate },
+            value: { date: dateValue },
           },
           token,
         );
         fieldsSet.push('Start date');
       } else {
-        addWarning('Start date', 'Field not found in project', defaults.startDate);
+        addWarning(
+          'Start date',
+          'Field not found in project',
+          defaults.startDate ?? 'use_current_date',
+        );
       }
     }
 

--- a/src/lib/github-project.ts
+++ b/src/lib/github-project.ts
@@ -41,6 +41,8 @@ export interface FieldOption {
 export interface IterationOption {
   id: string;
   title: string;
+  startDate?: string;
+  duration?: number;
 }
 
 /**
@@ -202,6 +204,8 @@ export async function getProject(projectUrl: string, token: string): Promise<Pro
         iterations {
           id
           title
+          startDate
+          duration
         }
       }
     }
@@ -245,7 +249,7 @@ export async function getProject(projectUrl: string, token: string): Promise<Pro
     dataType?: ProjectFieldType;
     options?: Array<{ id: string; name: string }>;
     configuration?: {
-      iterations: Array<{ id: string; title: string }>;
+      iterations: Array<{ id: string; title: string; startDate?: string; duration?: number }>;
     };
   }
 
@@ -501,6 +505,106 @@ export function findOption(field: ProjectField, name: string): FieldOption | und
  */
 export function findIteration(field: ProjectField, title: string): IterationOption | undefined {
   return field.iterations?.find((i) => i.title.toLowerCase() === title.toLowerCase());
+}
+
+/**
+ * Calculate the end date of an iteration
+ *
+ * @param iteration - Iteration with startDate and duration
+ * @returns End date as Date object, or undefined if missing data
+ */
+function calculateIterationEndDate(iteration: IterationOption): Date | undefined {
+  if (!iteration.startDate || iteration.duration === undefined) {
+    return undefined;
+  }
+  const startDate = new Date(iteration.startDate);
+  const endDate = new Date(startDate);
+  endDate.setDate(endDate.getDate() + iteration.duration);
+  return endDate;
+}
+
+/**
+ * Get the current iteration based on today's date
+ *
+ * Finds the iteration where today falls within the startDate to endDate range.
+ * If no current iteration is found, falls back to the closest iteration
+ * (next upcoming or most recent past).
+ *
+ * @param field - Project field with iterations
+ * @param referenceDate - Date to use for comparison (defaults to today)
+ * @returns Current or closest iteration, or undefined if no iterations exist
+ *
+ * @example
+ * ```ts
+ * const iterationField = findField(project.fields, 'Iteration');
+ * const currentIteration = getCurrentIteration(iterationField);
+ * if (currentIteration) {
+ *   console.log(`Current sprint: ${currentIteration.title}`);
+ * }
+ * ```
+ */
+export function getCurrentIteration(
+  field: ProjectField,
+  referenceDate: Date = new Date(),
+): IterationOption | undefined {
+  const iterations = field.iterations;
+  if (!iterations || iterations.length === 0) {
+    return undefined;
+  }
+
+  // Filter iterations with valid date info
+  const iterationsWithDates = iterations.filter(
+    (i) => i.startDate && i.duration !== undefined,
+  );
+
+  if (iterationsWithDates.length === 0) {
+    // No iterations with date info, return the first one as fallback
+    return iterations[0];
+  }
+
+  // Normalize reference date to start of day for consistent comparison
+  const today = new Date(referenceDate);
+  today.setHours(0, 0, 0, 0);
+
+  // Find iteration where today is within the date range
+  for (const iteration of iterationsWithDates) {
+    const startDate = new Date(iteration.startDate!);
+    startDate.setHours(0, 0, 0, 0);
+    const endDate = calculateIterationEndDate(iteration)!;
+    endDate.setHours(0, 0, 0, 0);
+
+    if (today >= startDate && today <= endDate) {
+      return iteration;
+    }
+  }
+
+  // No current iteration found, find the closest one
+  let closestIteration: IterationOption | undefined;
+  let smallestDiff = Infinity;
+
+  for (const iteration of iterationsWithDates) {
+    const startDate = new Date(iteration.startDate!);
+    startDate.setHours(0, 0, 0, 0);
+    const endDate = calculateIterationEndDate(iteration)!;
+    endDate.setHours(0, 0, 0, 0);
+
+    // Calculate distance to this iteration
+    let diff: number;
+    if (today < startDate) {
+      // Future iteration - distance to start
+      diff = startDate.getTime() - today.getTime();
+    } else {
+      // Past iteration - distance from end
+      diff = today.getTime() - endDate.getTime();
+    }
+
+    if (diff < smallestDiff) {
+      smallestDiff = diff;
+      closestIteration = iteration;
+    }
+  }
+
+  return closestIteration;
 }
 
 // Re-export parseProjectUrl for convenience

--- a/src/templates/project.toml
+++ b/src/templates/project.toml
@@ -35,6 +35,16 @@ status = "Planned"
 # Target date (YYYY-MM-DD format)
 # target_date = "2026-01-12"
 
+# Dynamic field values (automatically determined at runtime)
+# These are used when static values above are not specified
+
+# Automatically set to current Sprint based on today's date
+# If today is not within any Sprint, uses the closest Sprint
+use_current_iteration = true
+
+# Automatically set to today's date when issue is created
+use_current_date = true
+
 [pr]
 # Pull Request Status Update Configuration
 # These settings control the pr-status-update workflow

--- a/tests/github-project_test.ts
+++ b/tests/github-project_test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for github-project library
+ */
+
+import { assertEquals } from '@std/assert';
+import { describe, it } from '@std/testing/bdd';
+import {
+  findIteration,
+  getCurrentIteration,
+  type IterationOption,
+  type ProjectField,
+} from '../src/lib/github-project.ts';
+
+describe('findIteration', () => {
+  const mockField: ProjectField = {
+    id: 'field1',
+    name: 'Iteration',
+    type: 'ITERATION',
+    iterations: [
+      { id: 'iter1', title: 'Sprint 1' },
+      { id: 'iter2', title: 'Sprint 2' },
+      { id: 'iter3', title: 'Sprint 3' },
+    ],
+  };
+
+  it('should find iteration by exact title', () => {
+    const result = findIteration(mockField, 'Sprint 2');
+    assertEquals(result?.id, 'iter2');
+    assertEquals(result?.title, 'Sprint 2');
+  });
+
+  it('should find iteration case-insensitively', () => {
+    const result = findIteration(mockField, 'sprint 1');
+    assertEquals(result?.id, 'iter1');
+  });
+
+  it('should return undefined for non-existent iteration', () => {
+    const result = findIteration(mockField, 'Sprint 99');
+    assertEquals(result, undefined);
+  });
+});
+
+describe('getCurrentIteration', () => {
+  // Helper to create a date string in YYYY-MM-DD format
+  const toDateString = (date: Date): string => {
+    return date.toISOString().split('T')[0];
+  };
+
+  // Helper to create iterations relative to a reference date
+  const createIterationsAroundDate = (
+    referenceDate: Date,
+  ): IterationOption[] => {
+    const pastStart = new Date(referenceDate);
+    pastStart.setDate(pastStart.getDate() - 21); // 3 weeks ago
+
+    const currentStart = new Date(referenceDate);
+    currentStart.setDate(currentStart.getDate() - 3); // 3 days ago (still active)
+
+    const futureStart = new Date(referenceDate);
+    futureStart.setDate(futureStart.getDate() + 11); // Starts in 11 days
+
+    return [
+      {
+        id: 'past',
+        title: 'Sprint 1',
+        startDate: toDateString(pastStart),
+        duration: 14, // 2 weeks
+      },
+      {
+        id: 'current',
+        title: 'Sprint 2',
+        startDate: toDateString(currentStart),
+        duration: 14, // 2 weeks
+      },
+      {
+        id: 'future',
+        title: 'Sprint 3',
+        startDate: toDateString(futureStart),
+        duration: 14, // 2 weeks
+      },
+    ];
+  };
+
+  it('should return current iteration when today is within range', () => {
+    const today = new Date();
+    const iterations = createIterationsAroundDate(today);
+    const field: ProjectField = {
+      id: 'field1',
+      name: 'Iteration',
+      type: 'ITERATION',
+      iterations,
+    };
+
+    const result = getCurrentIteration(field, today);
+    assertEquals(result?.id, 'current');
+    assertEquals(result?.title, 'Sprint 2');
+  });
+
+  it('should return closest future iteration when no current iteration', () => {
+    const today = new Date();
+    const futureStart = new Date(today);
+    futureStart.setDate(futureStart.getDate() + 5);
+
+    const farFutureStart = new Date(today);
+    farFutureStart.setDate(farFutureStart.getDate() + 30);
+
+    const iterations: IterationOption[] = [
+      {
+        id: 'near',
+        title: 'Near Sprint',
+        startDate: toDateString(futureStart),
+        duration: 14,
+      },
+      {
+        id: 'far',
+        title: 'Far Sprint',
+        startDate: toDateString(farFutureStart),
+        duration: 14,
+      },
+    ];
+
+    const field: ProjectField = {
+      id: 'field1',
+      name: 'Iteration',
+      type: 'ITERATION',
+      iterations,
+    };
+
+    const result = getCurrentIteration(field, today);
+    assertEquals(result?.id, 'near');
+  });
+
+  it('should return closest past iteration when only past iterations exist', () => {
+    const today = new Date();
+    const recentPastStart = new Date(today);
+    recentPastStart.setDate(recentPastStart.getDate() - 20);
+
+    const oldPastStart = new Date(today);
+    oldPastStart.setDate(oldPastStart.getDate() - 50);
+
+    const iterations: IterationOption[] = [
+      {
+        id: 'old',
+        title: 'Old Sprint',
+        startDate: toDateString(oldPastStart),
+        duration: 14,
+      },
+      {
+        id: 'recent',
+        title: 'Recent Sprint',
+        startDate: toDateString(recentPastStart),
+        duration: 14,
+      },
+    ];
+
+    const field: ProjectField = {
+      id: 'field1',
+      name: 'Iteration',
+      type: 'ITERATION',
+      iterations,
+    };
+
+    const result = getCurrentIteration(field, today);
+    assertEquals(result?.id, 'recent');
+  });
+
+  it('should return undefined when no iterations exist', () => {
+    const field: ProjectField = {
+      id: 'field1',
+      name: 'Iteration',
+      type: 'ITERATION',
+      iterations: [],
+    };
+
+    const result = getCurrentIteration(field);
+    assertEquals(result, undefined);
+  });
+
+  it('should return first iteration when no date info available', () => {
+    const iterations: IterationOption[] = [
+      { id: 'iter1', title: 'Sprint 1' },
+      { id: 'iter2', title: 'Sprint 2' },
+    ];
+
+    const field: ProjectField = {
+      id: 'field1',
+      name: 'Iteration',
+      type: 'ITERATION',
+      iterations,
+    };
+
+    const result = getCurrentIteration(field);
+    assertEquals(result?.id, 'iter1');
+  });
+
+  it('should handle iteration on start date boundary', () => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const iterations: IterationOption[] = [
+      {
+        id: 'starting',
+        title: 'Starting Today',
+        startDate: toDateString(today),
+        duration: 14,
+      },
+    ];
+
+    const field: ProjectField = {
+      id: 'field1',
+      name: 'Iteration',
+      type: 'ITERATION',
+      iterations,
+    };
+
+    const result = getCurrentIteration(field, today);
+    assertEquals(result?.id, 'starting');
+  });
+
+  it('should handle iteration on end date boundary', () => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const startDate = new Date(today);
+    startDate.setDate(startDate.getDate() - 14); // Started 14 days ago, ends today
+
+    const iterations: IterationOption[] = [
+      {
+        id: 'ending',
+        title: 'Ending Today',
+        startDate: toDateString(startDate),
+        duration: 14,
+      },
+    ];
+
+    const field: ProjectField = {
+      id: 'field1',
+      name: 'Iteration',
+      type: 'ITERATION',
+      iterations,
+    };
+
+    const result = getCurrentIteration(field, today);
+    assertEquals(result?.id, 'ending');
+  });
+});

--- a/tests/link-issue_test.ts
+++ b/tests/link-issue_test.ts
@@ -55,4 +55,28 @@ url = "https://github.com/users/testuser/projects/1"
     const result = parseToml(content);
     assertEquals(result.project.url, 'https://github.com/users/testuser/projects/1');
   });
+
+  it('should parse boolean values for dynamic settings', () => {
+    const content = `
+[defaults]
+use_current_iteration = true
+use_current_date = false
+    `;
+    const result = parseToml(content);
+    assertEquals(result.defaults.use_current_iteration, true);
+    assertEquals(result.defaults.use_current_date, false);
+  });
+
+  it('should parse mixed static and dynamic settings', () => {
+    const content = `
+[defaults]
+status = "Planned"
+use_current_iteration = true
+use_current_date = true
+    `;
+    const result = parseToml(content);
+    assertEquals(result.defaults.status, 'Planned');
+    assertEquals(result.defaults.use_current_iteration, true);
+    assertEquals(result.defaults.use_current_date, true);
+  });
 });


### PR DESCRIPTION
## 概要

`issue-to-project.yml`ワークフローで、IssueをGitHub Projectに追加する際に、SprintとStart dateを自動的に設定する機能を追加しました。

## 変更内容

### ✨ 新機能

- **動的Sprint設定**: `use_current_iteration = true`で現在のSprintを自動設定
- **動的日付設定**: `use_current_date = true`でIssue作成日を自動設定
- **`getCurrentIteration()`関数**: 今日の日付が範囲内にあるIterationを自動検出
- **フォールバック機能**: 現在のSprintがない場合、最も近いSprintを使用

### 📝 ドキュメント

- `project.toml`テンプレートに新しい設定項目を追加
- `.github/project.toml`で動的設定を有効化

### ✅ テスト

- `getCurrentIteration()`関数の包括的なテストを追加
- TOML解析の新しい設定項目のテストを追加

## 技術的詳細

### 設定ファイル形式

```toml
[defaults]
# 静的指定（優先）
# iteration = "Sprint 1"
# start_date = "2026-01-05"

# 動的指定（新規追加）
use_current_iteration = true
use_current_date = true
```

### 優先順位

静的指定（`iteration`, `start_date`）が動的指定より優先されます。

### Sprint判定ロジック

1. 今日の日付が開始日〜終了日の範囲内にあるIterationを検索
2. 見つからない場合、最も近いIteration（次に始まる or 直前に終了）を使用

## テスト

- [x] ユニットテスト追加
- [x] 統合テスト追加（`getCurrentIteration()`）
- [x] 境界値テスト（開始日・終了日）

## チェックリスト

- [x] コードレビュー準備完了
- [x] ドキュメント更新

## 関連Issue

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)