### PR TITLE
docs: add documentation for running hewg directly from GitHub without installation

### DIFF
--- a/.devcontainer/scripts/post.sh
+++ b/.devcontainer/scripts/post.sh
@@ -11,10 +11,16 @@ curl -fsSL https://deno.land/install.sh | sh
 export DENO_INSTALL="$HOME/.deno"
 export PATH="$DENO_INSTALL/bin:$PATH"
 
-# Add Deno to PATH for future shells
+# Add Deno to PATH for future shells (bashrc for interactive, profile for non-interactive)
 if ! grep -q 'DENO_INSTALL' ~/.bashrc 2>/dev/null; then
   echo 'export DENO_INSTALL="$HOME/.deno"' >> ~/.bashrc
   echo 'export PATH="$DENO_INSTALL/bin:$PATH"' >> ~/.bashrc
+fi
+
+# Also add to ~/.profile for non-interactive shells (e.g., Claude Code)
+if ! grep -q 'DENO_INSTALL' ~/.profile 2>/dev/null; then
+  echo 'export DENO_INSTALL="$HOME/.deno"' >> ~/.profile
+  echo 'export PATH="$DENO_INSTALL/bin:$PATH"' >> ~/.profile
 fi
 
 # Verify Deno installation

--- a/README.md
+++ b/README.md
@@ -15,20 +15,80 @@ A versatile CLI framework for Deno.
 
 ## Installation
 
+### Run without Installation (Recommended for Quick Start)
+
+You can run hewg directly from GitHub without any installation:
+
+```bash
+# Show help
+deno run --allow-read --allow-env \
+  https://raw.githubusercontent.com/wtisd/hewg/develop/src/main.ts --help
+
+# Run hello command
+deno run --allow-read --allow-env \
+  https://raw.githubusercontent.com/wtisd/hewg/develop/src/main.ts hello World
+
+# Run setup-actions command (requires --allow-write for file generation)
+deno run --allow-read --allow-env --allow-write \
+  https://raw.githubusercontent.com/wtisd/hewg/develop/src/main.ts setup-actions
+```
+
+#### Required Permissions
+
+| Permission      | Description                   | Required For              |
+| --------------- | ----------------------------- | ------------------------- |
+| `--allow-read`  | Read configuration files      | All commands              |
+| `--allow-env`   | Access environment variables  | All commands              |
+| `--allow-write` | Generate files                | `setup-actions` command   |
+| `--allow-net`   | Network access for GitHub API | `link-issue`, `pr-status` |
+
+#### Command Examples
+
+```bash
+# Basic commands (read-only)
+HEWG_URL="https://raw.githubusercontent.com/wtisd/hewg/develop/src/main.ts"
+
+# Show version
+deno run --allow-read --allow-env $HEWG_URL version
+
+# Show version as JSON
+deno run --allow-read --allow-env $HEWG_URL version --json
+
+# Greeting with options
+deno run --allow-read --allow-env $HEWG_URL hello --loud --count 3
+
+# Setup GitHub Actions (generates files)
+deno run --allow-read --allow-env --allow-write $HEWG_URL setup-actions
+```
+
 ### As a module
 
 ```ts
 import { createCli } from 'jsr:@erdtree/hewg';
 ```
 
-### As a CLI tool
+### Compile to binary
 
 ```bash
-# Run directly
-deno run --allow-read --allow-env https://jsr.io/@erdtree/hewg/src/main.ts
+# Clone and compile
+git clone https://github.com/wtisd/hewg.git
+cd hewg
+deno compile --allow-read --allow-env --allow-write --allow-net --output hewg src/main.ts
 
-# Or compile to binary
-deno compile --allow-read --allow-env --output hewg src/main.ts
+# Or use deno task
+deno task compile
+```
+
+### Global Installation
+
+```bash
+# Install globally from GitHub
+deno install -g -n hewg --allow-read --allow-env --allow-write --allow-net \
+  https://raw.githubusercontent.com/wtisd/hewg/develop/src/main.ts
+
+# Now you can use hewg directly
+hewg --help
+hewg setup-actions
 ```
 
 ## Quick Start
@@ -216,14 +276,19 @@ hewg/
 │           ├── hello.ts   # Hello command
 │           └── version.ts # Version command
 ├── tests/
-│   ├── cli_test.ts        # CLI tests
-│   ├── colors_test.ts     # Color utilities tests
-│   ├── commands_test.ts   # Command tests
-│   └── mod_test.ts        # Module export tests
+│   ├── unit/              # Unit tests
+│   │   ├── colors_test.ts
+│   │   ├── commands_test.ts
+│   │   └── mod_test.ts
+│   ├── integration/       # Integration tests
+│   │   ├── cli_test.ts
+│   │   └── ...
+│   └── e2e/               # End-to-end tests
 └── .github/
     └── workflows/
-        ├── ci.yml         # CI workflow
-        └── release.yml    # Release workflow
+        ├── ci-typescript.yml  # CI workflow
+        ├── build.yml          # Build workflow
+        └── release.yml        # Release workflow
 ```
 
 ## GitHub Actions


### PR DESCRIPTION
## 概要

hewgコマンドをGitHub経由でインストールなしで直接実行できることをREADMEに明記し、ユーザーが簡単に利用開始できるようにしました。

## 変更内容

### 📝 ドキュメント

- **「Run without Installation」セクション追加**: GitHub raw URL経由での直接実行方法を記載
- **権限一覧テーブル追加**: 各コマンドに必要な権限を明記
- **コマンド例追加**: 環境変数 `$HEWG_URL` を使った実用的な例
- **グローバルインストール方法追加**: `deno install` による永続的なインストール方法
- **プロジェクト構造更新**: 新しいテストディレクトリ構造を反映

### 🔧 修正

- **Deno PATH修正**: `~/.profile` にもDeno PATHを追加し、非対話型シェル（Claude Code等）でDenoが利用可能に

## 技術的詳細

### 追加された実行方法

```bash
# 直接実行
deno run --allow-read --allow-env \
  https://raw.githubusercontent.com/wtisd/hewg/develop/src/main.ts --help

# setup-actionsコマンド
deno run --allow-read --allow-env --allow-write \
  https://raw.githubusercontent.com/wtisd/hewg/develop/src/main.ts setup-actions

# グローバルインストール
deno install -g -n hewg --allow-read --allow-env --allow-write --allow-net \
  https://raw.githubusercontent.com/wtisd/hewg/develop/src/main.ts
```

### 権限一覧

| Permission | Description | Required For |
|------------|-------------|--------------|
| `--allow-read` | 設定ファイルの読み取り | 全コマンド |
| `--allow-env` | 環境変数の参照 | 全コマンド |
| `--allow-write` | ファイル生成 | `setup-actions` |
| `--allow-net` | GitHub API | `link-issue`, `pr-status` |

## テスト

- [x] ローカルでの動作確認
- [x] deno fmt チェック通過
- [x] deno lint チェック通過
- [x] 全テスト成功 (28 passed)

## チェックリスト

- [x] コードレビュー準備完了
- [x] Lintチェック通過 (deno lint)
- [x] フォーマットチェック通過 (deno fmt)
- [x] 全テスト成功 (deno test)
- [x] ドキュメント更新

## 関連Issue

Closes #26